### PR TITLE
rename configuration for backword compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ This action sends mention to your slack account when you have been mentioned at 
 
 ## Inputs
 
-| Name | Required | Default | Description |
-| :--- | :--- | :--- | :--- |
-| configuration | Yes | .github/mention-to-slack.yml | Mapping config for Github username to Slack member ID. |
-| slack-webhook-url | Yes | Null | Slack Incomming Webhook URL to notify. |
-| repo-token | Yes | Null | Github access token to fetch .github/mention-to-slack.yml file. |
-| bot-name | No | Github Mention To Slack | Display name for this bot on Slack. |
-| icon-url | No | Null | Display icon url for this bot on Slack. |
-| run-id | No | Null | Used for the link in the error message when an error occurs. |
+| Name               | Required | Default                      | Description                                                     |
+| :----------------- | :------- | :--------------------------- | :-------------------------------------------------------------- |
+| configuration-path | Yes      | .github/mention-to-slack.yml | Mapping config for Github username to Slack member ID.          |
+| slack-webhook-url  | Yes      | Null                         | Slack Incomming Webhook URL to notify.                          |
+| repo-token         | Yes      | Null                         | Github access token to fetch .github/mention-to-slack.yml file. |
+| bot-name           | No       | Github Mention To Slack      | Display name for this bot on Slack.                             |
+| icon-url           | No       | Null                         | Display icon url for this bot on Slack.                         |
+| run-id             | No       | Null                         | Used for the link in the error message when an error occurs.    |
 
 ## Example usage
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -53,7 +53,7 @@ describe("src/main", () => {
   describe("execPrReviewRequestedMention", () => {
     const dummyInputs: AllInputs = {
       repoToken: "",
-      configuration: "",
+      configurationPath: "",
       slackWebhookUrl: "dummy_url",
       iconUrl: "",
       botName: "",
@@ -175,7 +175,7 @@ describe("src/main", () => {
   describe("execNormalMention", () => {
     const dummyInputs: AllInputs = {
       repoToken: "",
-      configuration: "",
+      configurationPath: "",
       slackWebhookUrl: "dummy_url",
       iconUrl: "",
       botName: "",

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: "Github mention to Slack"
 description: "Convert Github mention to Slack mention"
 inputs:
-  configuration:
+  configuration-path:
     description: "Mapping config for Github username to Slack member ID."
     required: true
     default: ".github/mention-to-slack.yml"

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ import {
 
 export type AllInputs = {
   repoToken: string;
-  configuration: string;
+  configurationPath: string;
   slackWebhookUrl: string;
   iconUrl?: string;
   botName?: string;
@@ -27,14 +27,14 @@ export const convertToSlackUsername = async (
   githubUsernames: string[],
   githubClient: typeof GithubRepositoryImpl,
   repoToken: string,
-  configuration: string,
+  configurationPath: string,
   context: Pick<Context, "repo" | "sha">
 ): Promise<string[]> => {
   const mapping = await githubClient.loadNameMappingConfig(
     repoToken,
     context.repo.owner,
     context.repo.repo,
-    configuration,
+    configurationPath,
     context.sha
   );
 
@@ -52,7 +52,7 @@ export const execPrReviewRequestedMention = async (
   slackClient: typeof SlackRepositoryImpl,
   context: Pick<Context, "repo" | "sha">
 ): Promise<void> => {
-  const { repoToken, configuration } = allInputs;
+  const { repoToken, configurationPath } = allInputs;
   const requestedGithubUsername =
     payload.requested_reviewer?.login || payload.requested_team?.name;
 
@@ -64,7 +64,7 @@ export const execPrReviewRequestedMention = async (
     [requestedGithubUsername],
     githubClient,
     repoToken,
-    configuration,
+    configurationPath,
     context
   );
 
@@ -101,12 +101,12 @@ export const execNormalMention = async (
     return;
   }
 
-  const { repoToken, configuration } = allInputs;
+  const { repoToken, configurationPath } = allInputs;
   const slackIds = await convertToSlackUsername(
     githubUsernames,
     githubClient,
     repoToken,
-    configuration,
+    configurationPath,
     context
   );
 
@@ -164,14 +164,14 @@ const getAllInputs = (): AllInputs => {
 
   const iconUrl = core.getInput("icon-url", { required: false });
   const botName = core.getInput("bot-name", { required: false });
-  const configuration = core.getInput("configuration", {
+  const configurationPath = core.getInput("configuration-path", {
     required: true,
   });
   const runId = core.getInput("run-id", { required: false });
 
   return {
     repoToken,
-    configuration,
+    configurationPath,
     slackWebhookUrl,
     iconUrl,
     botName,

--- a/src/modules/github.ts
+++ b/src/modules/github.ts
@@ -121,16 +121,16 @@ export const GithubRepositoryImpl = {
     repoToken: string,
     owner: string,
     repo: string,
-    configuration: string,
+    configurationPath: string,
     sha: string
   ): Promise<MappingFile> => {
     const pattern = /https?:\/\/[-_.!~*'()a-zA-Z0-9;/?:@&=+$,%#]+/g;
-    if (pattern.test(configuration)) {
-      const response = await axios.get(configuration);
+    if (pattern.test(configurationPath)) {
+      const response = await axios.get(configurationPath);
       const configObject = load(response.data);
 
       if (configObject === undefined) {
-        throw new Error(`failed to load yaml\n${configuration}`);
+        throw new Error(`failed to load yaml\n${configurationPath}`);
       }
 
       return configObject as MappingFile;
@@ -140,7 +140,7 @@ export const GithubRepositoryImpl = {
     const response = await githubClient.rest.repos.getContent({
       owner,
       repo,
-      path: configuration,
+      path: configurationPath,
       ref: sha,
     });
 


### PR DESCRIPTION
rename input name `configuration` to `configuration-path` for backword compatibility

