### PR TITLE
feature: add repository name when request review

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -86,6 +86,13 @@ describe("src/main", () => {
           html_url: "pr_url",
           number: 1,
         },
+        repository: {
+          full_name: 'abeyuya/github-actions-test',
+          name: 'github-actions-test',
+          owner: {
+            login: 'abeyuya'
+          }
+        },
         sender: {
           login: "sender_github_username",
           type: "sender_type",
@@ -106,6 +113,7 @@ describe("src/main", () => {
       expect(call[1].includes("<@slack_user_1>")).toEqual(true);
       expect(call[1].includes("<pr_url|pr_title>")).toEqual(true);
       expect(call[1].includes("by sender_github_username")).toEqual(true);
+      expect(call[1].includes("on abeyuya/github-actions-test")).toEqual(true);
     });
 
     it("should not call postToSlack if requested_user is not listed in mapping", async () => {
@@ -121,6 +129,13 @@ describe("src/main", () => {
           title: "pr_title",
           html_url: "pr_url",
           number: 1,
+        },
+        repository: {
+          full_name: 'abeyuya/github-actions-test',
+          name: 'github-actions-test',
+          owner: {
+            login: 'abeyuya'
+          }
         },
         sender: {
           login: "sender_github_username",
@@ -149,6 +164,13 @@ describe("src/main", () => {
           html_url: "pr_url",
           number: 1,
         },
+        repository: {
+          full_name: 'abeyuya/github-actions-test',
+          name: 'github-actions-test',
+          owner: {
+            login: 'abeyuya'
+          }
+        },
         requested_team: {
           name: "github_team_1",
         },
@@ -172,6 +194,7 @@ describe("src/main", () => {
       expect(call[1].includes("<!subteam^slack_usergroup_1>")).toEqual(true);
       expect(call[1].includes("<pr_url|pr_title>")).toEqual(true);
       expect(call[1].includes("by sender_github_username")).toEqual(true);
+      expect(call[1].includes("on abeyuya/github-actions-test")).toEqual(true);
     });
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,10 +88,11 @@ export const execPrReviewRequestedMention = async (
 
   const title = payload.pull_request?.title;
   const url = payload.pull_request?.html_url;
+  const repoName = payload.repository?.full_name;
   const requestUsername = payload.sender?.login;
 
   const slackMention = getSlackMention(slackUserIds[0], slackUserGroupIds[0]);
-  const message = `${slackMention} has been requested to review <${url}|${title}> by ${requestUsername}.`;
+  const message = `${slackMention} has been requested to review <${url}|${title}> by ${requestUsername} on ${repoName}.`;
   const { slackWebhookUrl, iconUrl, botName } = allInputs;
 
   await slackClient.postToSlack(slackWebhookUrl, message, { iconUrl, botName });


### PR DESCRIPTION
In cases where this action is used on multiple repositories, but review requests are sent on the same channel, it's difficult to know which project the request is related to.

This PR adds the repository name in the form of organization/repository to the message to help identify which project needs code review.