### PR TITLE
Fix release-latest-tag CI auth by switching to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release-latest-tag.yml
+++ b/.github/workflows/release-latest-tag.yml
@@ -9,10 +9,11 @@ jobs:
   push-latest-tag:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:
-          persist-credentials: false
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
@@ -40,8 +41,4 @@ jobs:
           git diff-index --quiet HEAD || (git commit -m"update build ${{ github.run_number }}" && git tag latest -f)
       - name: Push changes
         run: |
-          git push \
-            "https://${{ github.actor }}:${{ secrets.MY_GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" \
-            HEAD:release \
-            -f \
-            --tags
+          git push origin HEAD:release -f --tags


### PR DESCRIPTION
## Summary

`Release latest tag` ワークフローの `Push changes` ステップが認証エラーで失敗していたため修正。

- 失敗例: https://github.com/abeyuya/actions-mention-to-slack/actions/runs/25931979354/job/76227840477
  ```
  remote: Invalid username or token. Password authentication is not supported for Git operations.
  fatal: Authentication failed for 'https://github.com/abeyuya/actions-mention-to-slack.git/'
  ```

## Root cause

`secrets.MY_GITHUB_TOKEN` (2020-09-21 に作成された PAT) が失効しているのが原因。

## Fix

同一リポジトリへの push なので PAT は不要。ジョブに `permissions: contents: write` を付与してデフォルトの `GITHUB_TOKEN` で push するように変更した。

- `persist-credentials: false` を削除 (= actions/checkout がデフォルトで `GITHUB_TOKEN` を git credential に設定する)
- push URL からトークン埋め込みを削除し `git push origin HEAD:release -f --tags` に簡略化
- `MY_GITHUB_TOKEN` 自体は `production-test.yml` (クロスリポへのコメント) で引き続き利用されているのでシークレットは残してOK

## Test plan

- [ ] このPRを master にマージ後、`Release latest tag` ワークフローが成功し `release` ブランチが更新されること
- [ ] `latest` タグが force-update されること