### PR TITLE
axios の依存を廃止し、ネイティブの fetch に置き換え

### DIFF
--- a/__tests__/modules/mappingConfig.test.ts
+++ b/__tests__/modules/mappingConfig.test.ts
@@ -20,6 +20,11 @@ describe("mappingConfig", () => {
 
   describe("MappingConfigRepositoryImpl", () => {
     describe("loadFromUrl", () => {
+      const originalFetch = globalThis.fetch;
+      afterEach(() => {
+        globalThis.fetch = originalFetch;
+      });
+
       it("should return yaml", async () => {
         const fetchMock = jest.fn().mockResolvedValueOnce({
           ok: true,

--- a/__tests__/modules/mappingConfig.test.ts
+++ b/__tests__/modules/mappingConfig.test.ts
@@ -1,5 +1,3 @@
-import axios from "axios";
-
 import {
   isUrl,
   MappingConfigRepositoryImpl,
@@ -23,15 +21,17 @@ describe("mappingConfig", () => {
   describe("MappingConfigRepositoryImpl", () => {
     describe("loadFromUrl", () => {
       it("should return yaml", async () => {
-        const spy = jest
-          .spyOn(axios, "get")
-          .mockResolvedValueOnce({ data: 'github_user_id: "XXXXXXX"' });
+        const fetchMock = jest.fn().mockResolvedValueOnce({
+          ok: true,
+          text: () => Promise.resolve('github_user_id: "XXXXXXX"'),
+        } as Response);
+        globalThis.fetch = fetchMock;
 
         const result = await MappingConfigRepositoryImpl.loadFromUrl(
           "https://example.com"
         );
 
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
         expect({ github_user_id: "XXXXXXX" }).toEqual(result);
       });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@actions/core": "^1.10.0",
         "@actions/github": "^5.1.1",
         "@vercel/ncc": "^0.36.1",
-        "axios": "^0.27.0",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21"
       },
@@ -1914,33 +1913,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
-    "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -2228,17 +2200,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2339,14 +2300,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/deprecation": {
@@ -2879,25 +2832,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -4129,25 +4063,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -6707,32 +6622,6 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
-    "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
-    },
     "babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -6954,14 +6843,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -7036,11 +6917,6 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "deprecation": {
       "version": "2.3.1",
@@ -7428,11 +7304,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
-    },
-    "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -8360,19 +8231,6 @@
       "requires": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
-      }
-    },
-    "mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-    },
-    "mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "requires": {
-        "mime-db": "1.52.0"
       }
     },
     "mimic-fn": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.1.1",
     "@vercel/ncc": "^0.36.1",
-    "axios": "^0.27.0",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21"
   },

--- a/src/modules/mappingConfig.ts
+++ b/src/modules/mappingConfig.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { load } from "js-yaml";
 import { getOctokit } from "@actions/github";
 
@@ -11,8 +10,13 @@ export type MappingFile = {
 
 export const MappingConfigRepositoryImpl = {
   downloadFromUrl: async (url: string) => {
-    const response = await axios.get<string>(url);
-    return response.data;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(
+        `Failed to download mapping config: ${response.status} ${response.statusText}`
+      );
+    }
+    return response.text();
   },
 
   loadYaml: (data: string) => {

--- a/src/modules/slack.ts
+++ b/src/modules/slack.ts
@@ -1,5 +1,3 @@
-import axios from "axios";
-
 export const convertGithubTextToBlockquotesText = (githubText: string) => {
   const t = githubText
     .split("\n")
@@ -111,14 +109,18 @@ export const SlackRepositoryImpl = {
       slackPostParam.icon_emoji = defaultIconEmoji;
     }
 
-    const result = await axios.post<SlackPostResult>(
-      webhookUrl,
-      JSON.stringify(slackPostParam),
-      {
-        headers: { "Content-Type": "application/json" },
-      }
-    );
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(slackPostParam),
+    });
 
-    return result.data;
+    if (!response.ok) {
+      throw new Error(
+        `Failed to post to Slack: ${response.status} ${response.statusText}`
+      );
+    }
+
+    return { body: await response.text() };
   },
 };

--- a/src/modules/slack.ts
+++ b/src/modules/slack.ts
@@ -80,14 +80,12 @@ type SlackPostParam = {
 const defaultBotName = "Github Mention To Slack";
 const defaultIconEmoji = ":bell:";
 
-type SlackPostResult = Record<string, unknown>;
-
 export const SlackRepositoryImpl = {
   postToSlack: async (
     webhookUrl: string,
     message: string,
     options?: SlackOption
-  ): Promise<SlackPostResult> => {
+  ): Promise<string> => {
     const botName = (() => {
       const n = options?.botName;
       if (n && n !== "") {
@@ -121,6 +119,6 @@ export const SlackRepositoryImpl = {
       );
     }
 
-    return { body: await response.text() };
+    return response.text();
   },
 };


### PR DESCRIPTION
## Summary

- ランタイムが node24 (`action.yml`) なので、axios ではなく標準の `fetch` で十分。
- 依存ツリーから axios (0.27 系) と推移依存 (`follow-redirects` / `form-data` / `combined-stream` / `mime-types` / `mime-db` / `delayed-stream` / `asynckit`) を除去。
- 副次的な簡略化として、`postToSlack` の返却型を実態に合った `Promise<string>` に変更 (旧 `Promise<Record<string, unknown>>` は型と実体が乖離しており、実体は webhook が返すプレーンテキスト `ok`)。呼び出し側 (`main.ts`) ではデバッグログにしか使われておらず影響なし。
- テストの `globalThis.fetch` モックは `afterEach` で復元してリークを防止。

## Behavior parity

- axios はデフォルトで非 2xx を throw する。新実装も `!response.ok` でメッセージ付きの `Error` を投げるため等価。
- リダイレクト追従はどちらも有効 (axios 5 回 → undici 20 回)。今回の URL (ユーザー指定の YAML / Slack webhook) では問題なし。
- タイムアウト未設定なのも従来通り。

## Test plan

- [x] `npm run lint`
- [x] `npm test` (41 / 41 passed)
- [x] `npm run build` (ncc で `dist/index.js` 生成成功)
- [ ] 実環境の workflow で動作確認 (Slack 通知が届くこと)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSW8t6UqQYGWZTqvsn1DCS)_