### PR TITLE
Resolve open Dependabot alerts (lodash, minimatch, picomatch)

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,4 +1,3 @@
-import { cloneDeep } from "lodash";
 import { WebhookPayload } from "@actions/github/lib/interfaces";
 
 import {
@@ -312,7 +311,7 @@ describe("src/main", () => {
             postToSlack: jest.fn(),
           };
 
-          const overwritePayload = cloneDeep(prApprovePayload);
+          const overwritePayload = structuredClone(prApprovePayload);
           overwritePayload.review.body =
             "this is approve comment. @github_user hello";
 
@@ -338,7 +337,7 @@ describe("src/main", () => {
             postToSlack: jest.fn(),
           };
 
-          const overwritePayload = cloneDeep(prApprovePayload);
+          const overwritePayload = structuredClone(prApprovePayload);
           overwritePayload.review.body =
             "this is approve comment. @abeyuya-bot hello";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,11 @@
         "@actions/core": "^1.10.0",
         "@actions/github": "^5.1.1",
         "@vercel/ncc": "^0.36.1",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21"
+        "js-yaml": "^4.1.0"
       },
       "devDependencies": {
         "@types/jest": "29.5.6",
         "@types/js-yaml": "^4.0.5",
-        "@types/lodash": "4.14.197",
         "@typescript-eslint/eslint-plugin": "6.21.0",
         "@typescript-eslint/parser": "6.21.0",
         "eslint": "8.57.1",
@@ -1500,12 +1498,6 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
-    "node_modules/@types/lodash": {
-      "version": "4.14.197",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.197.tgz",
-      "integrity": "sha512-BMVOiWs0uNxHVlHBgzTIqJYmj+PgCo4euloGF+5m4okL3rEYzM2EEv78mw8zWSMM57dM7kVIgJ2QDvwHSoCI5g==",
-      "dev": true
-    },
     "node_modules/@types/node": {
       "version": "13.9.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.2.tgz",
@@ -1709,12 +1701,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3963,11 +3956,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -4305,10 +4293,11 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -6352,12 +6341,6 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.14.197",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.197.tgz",
-      "integrity": "sha512-BMVOiWs0uNxHVlHBgzTIqJYmj+PgCo4euloGF+5m4okL3rEYzM2EEv78mw8zWSMM57dM7kVIgJ2QDvwHSoCI5g==",
-      "dev": true
-    },
     "@types/node": {
       "version": "13.9.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.2.tgz",
@@ -6470,7 +6453,7 @@
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
+        "minimatch": "^9.0.7",
         "semver": "^7.5.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -6485,12 +6468,12 @@
           }
         },
         "minimatch": {
-          "version": "9.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+          "version": "9.0.9",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+          "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^2.0.1"
+            "brace-expansion": "^2.0.2"
           }
         },
         "semver": {
@@ -6602,7 +6585,7 @@
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
+        "picomatch": "^2.3.2"
       }
     },
     "arg": {
@@ -8005,7 +7988,7 @@
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
+        "picomatch": "^2.3.2"
       }
     },
     "jest-validate": {
@@ -8150,11 +8133,6 @@
         "p-locate": "^4.1.0"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -8230,7 +8208,7 @@
       "dev": true,
       "requires": {
         "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
+        "picomatch": "^2.3.2"
       }
     },
     "mimic-fn": {
@@ -8408,9 +8386,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true
     },
     "pirates": {

--- a/package.json
+++ b/package.json
@@ -7,13 +7,11 @@
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.1.1",
     "@vercel/ncc": "^0.36.1",
-    "js-yaml": "^4.1.0",
-    "lodash": "^4.17.21"
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "@types/jest": "29.5.6",
     "@types/js-yaml": "^4.0.5",
-    "@types/lodash": "4.14.197",
     "@typescript-eslint/eslint-plugin": "6.21.0",
     "@typescript-eslint/parser": "6.21.0",
     "eslint": "8.57.1",
@@ -21,6 +19,12 @@
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",
     "typescript": "5.2.2"
+  },
+  "overrides": {
+    "@typescript-eslint/typescript-estree": {
+      "minimatch": "^9.0.7"
+    },
+    "picomatch": "^2.3.2"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
## Summary

`abeyuya/actions-mention-to-slack` の open な Dependabot アラートのうち、axios 系以外（別途対応中）を解消する。

| # | severity | package | 対応 |
|---|----------|---------|------|
| 93 | high | minimatch | `overrides` で `@typescript-eslint/typescript-estree` 配下を `^9.0.7` に lift（実インストール 9.0.9） |
| 58 | medium | picomatch | `overrides` で `^2.3.2` に lift |
| 59, 60 | high / medium | lodash | テスト専用の `cloneDeep` を Node 17+ 標準の `structuredClone` に置換し、直接依存ごと削除 |
| 67 | medium | follow-redirects | axios → native fetch 化（既に master にマージ済み）でツリーから消滅。本 PR では追加対応不要 |

### 設計メモ
- `minimatch` はトップレベルにも `3.1.2` が存在する（jest / eslint 経由）。`overrides` をグローバルに `^9.0.7` にすると 3.x 系を必要とする箇所が壊れるリスクがあるため、`@typescript-eslint/typescript-estree` 配下にスコープして lift している。
- `picomatch` は調査の結果すべての参照が `^2.x` 要求なのでグローバル override で問題なし。
- `prApprovePayload` は JSON 互換のプレーンオブジェクトのため、`structuredClone` で安全に複製できる。

## Test plan

- [x] `npm install` 成功
- [x] `npm test` (jest) 41/41 pass
- [x] `npm run lint` (`tsc --noEmit && eslint`) clean
- [x] `npm run build` (ncc) 成功
- [x] lock 上の lift を確認
  - `node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch -> 9.0.9`
  - `node_modules/picomatch -> 2.3.2`
  - `node_modules/lodash` は削除
- [ ] merge 後、Dependabot が #58, #59, #60, #93 を fixed / auto-dismissed に変えることを確認

https://claude.ai/code/session_01JtGA9FFM5F1p7KhpWknqQV

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtGA9FFM5F1p7KhpWknqQV)_