### PR TITLE
Migrate production-test to GitHub App token + workflow_run trigger

### DIFF
--- a/.github/workflows/production-test.yml
+++ b/.github/workflows/production-test.yml
@@ -1,43 +1,39 @@
 name: Production test
 
 on:
-  push:
-    branches:
-      - release
+  workflow_run:
+    workflows: ["Release latest tag"]
+    types:
+      - completed
 
 jobs:
-  comment-to-issue:
+  post-test-comment:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      matrix:
+        target:
+          - { kind: issue, number: 7 }
+          - { kind: pull-request, number: 11 }
     steps:
-      - name: Create issue comment with user_name mention
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: abeyuya
+          repositories: github-actions-test
+      - name: Create ${{ matrix.target.kind }} comment with user_name mention
         uses: peter-evans/create-or-update-comment@v3
         with:
           repository: abeyuya/github-actions-test
-          token: ${{ secrets.MY_GITHUB_TOKEN }}
-          issue-number: 7
+          token: ${{ steps.app-token.outputs.token }}
+          issue-number: ${{ matrix.target.number }}
           body: |
             hey @abeyuya!
-            This is a test issue comment from [ci](https://github.com/abeyuya/actions-mention-to-slack/actions/runs/${{ github.run_id }}) to test abeyuya/actions-mention-to-slack.
-            [${{ github.event.head_commit.message }}](https://github.com/abeyuya/actions-mention-to-slack/commit/${{ github.sha }})
-
-            ```
-            github.event_name: ${{ github.event_name }}
-            ```
-  comment-to-pull-request:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Create pull request comment with user_name mention
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          repository: abeyuya/github-actions-test
-          token: ${{ secrets.MY_GITHUB_TOKEN }}
-          issue-number: 11
-          body: |
-            hey @abeyuya!
-            This is a test pull-request comment from [ci](https://github.com/abeyuya/actions-mention-to-slack/actions/runs/${{ github.run_id }}) to test abeyuya/actions-mention-to-slack.
-            [${{ github.event.head_commit.message }}](https://github.com/abeyuya/actions-mention-to-slack/commit/${{ github.sha }})
+            This is a test ${{ matrix.target.kind }} comment from [ci](https://github.com/abeyuya/actions-mention-to-slack/actions/runs/${{ github.run_id }}) to test abeyuya/actions-mention-to-slack.
+            [${{ github.event.workflow_run.head_commit.message }}](https://github.com/abeyuya/actions-mention-to-slack/commit/${{ github.event.workflow_run.head_sha }})
 
             ```
             github.event_name: ${{ github.event_name }}


### PR DESCRIPTION
## Summary

- `production-test.yml` の認証を期限切れ PAT `MY_GITHUB_TOKEN` から GitHub App installation token に置換 (`actions/create-github-app-token@v1`)。App は `actions-mention-to-slack` と `github-actions-test` にインストール済み、権限は Issues: write のみ。
- トリガーを `push: branches: [release]` から `workflow_run` (`Release latest tag` 完了) に変更。前者は #PR-not-applicable の commit 590dfdc で release workflow が default `GITHUB_TOKEN` に切り替わって以来発火しなくなっていた (GITHUB_TOKEN 起動の push は下流 workflow を起動しない仕様)。
- ほぼ同一だった 2 job を matrix で 1 job に統合。

## 関連 secret

- 追加: `APP_ID`, `APP_PRIVATE_KEY`
- マージ + 動作確認後に削除予定: `MY_GITHUB_TOKEN`

## Test plan

- [ ] このブランチを master にマージ
- [ ] 直後の master push で `Release latest tag` workflow が成功
- [ ] その完了をトリガーに `Production test` workflow が起動 (Actions タブで確認)
- [ ] matrix の 2 job (issue / pull-request) いずれも `create-github-app-token` が成功し、`abeyuya/github-actions-test` issue #7 / PR #11 にテストコメントが投稿される
- [ ] github-actions-test 側の `mention-to-slack.yml` が発火し、`@latest` の action 経由で Slack 通知が届く
- [ ] OK なら `MY_GITHUB_TOKEN` secret を削除