### PR TITLE
Skip minimatch major updates in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,10 @@
 {
-  "extends": ["config:base", ":disableDependencyDashboard"]
+  "extends": ["config:base", ":disableDependencyDashboard"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["minimatch"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- minimatch v10 で callable default export が削除されたが、依存グラフには未だ `minimatch(...)` を関数として呼び出す consumer (glob@7 via jest, @humanwhocodes/config-array, @eslint/eslintrc@2, test-exclude@6) がいるため、`overrides` でグローバルに v10 へ寄せると壊れる。
- `.github/renovate.json` に packageRule を追加し、minimatch の major bump (v10+) を当面 skip させる。
- これに伴い PR #328 (Update minimatch to v10) は close 予定。

## Test plan
- [ ] Renovate dry-run / 次回サイクルで minimatch v10 PR が再生成されないことを確認

https://claude.ai/code/session_017CvTWBMqqFbmu3QwYgYEu1