### PR TITLE
docs: note this action is an alternative to GitHub Scheduled reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 This action sends mention to your slack account when you have been mentioned at github.
 
+## About
+
+This action aims to be an alternative to GitHub's official [Scheduled reminders](https://docs.github.com/en/subscriptions-and-notifications/concepts/scheduled-reminders) (the real-time alerts part — review requests, mentions, etc.). If your organization has Scheduled reminders enabled and all the people you want to notify can use it, prefer the official feature.
+
+Use this action when Scheduled reminders are not available, for example:
+
+- Your organization has not enabled Scheduled reminders.
+- You want to notify outside collaborators, who cannot use Scheduled reminders even when the organization has it enabled.
+
 ## Feature
 
 - Send mention to slack if you have been mentioned

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Github mention to Slack"
-description: "Convert Github mention to Slack mention"
+description: "Convert Github mention to Slack mention. An alternative to GitHub Scheduled reminders for orgs without it enabled or for outside collaborators."
 inputs:
   configuration-path:
     description: "Path to config-yaml-file to convert Github username to Slack member ID."


### PR DESCRIPTION
## Summary

- README に `## About` セクションを追加し、本 action が GitHub 公式の [Scheduled reminders](https://docs.github.com/en/subscriptions-and-notifications/concepts/scheduled-reminders) のリアルタイムアラート部分の代替を目指していることを明記
- 公式機能が利用可能な場合はそちらを推奨しつつ、本 action の想定ユースケース (Scheduled reminders が有効化されていない org / outside collaborator) を提示
- Marketplace カードからも分かるよう `action.yml` の `description` も更新

## Test plan

- [ ] GitHub 上で README をプレビューし、`## About` が `## Feature` の直前に表示されリンク先が公式 docs を指していることを確認
- [ ] `action.yml` の YAML が valid で、`description` が更新されていることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_012EVsESMxPCxhkeBuZmqEzB)_