### PR TITLE
Switch create-github-app-token input to client-id

### DIFF
--- a/.github/workflows/production-test.yml
+++ b/.github/workflows/production-test.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: abeyuya
           repositories: github-actions-test
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: abeyuya
           repositories: github-actions-test


### PR DESCRIPTION
## Summary

- `actions/create-github-app-token` v3.1.0 で `app-id` 入力が deprecated になり、Production test 実行のたびに `Input 'app-id' has been deprecated with message: Use 'client-id' instead.` の warning が出ていた。
- `.github/workflows/production-test.yml` の `post-test-comment` / `dispatch-scheduled-reminder` 両ジョブの `app-id` を `client-id` に置き換え、対応する `APP_CLIENT_ID` repo secret を新設。
- 既存 `APP_ID` secret はこの PR では削除しない (他箇所で参照されていないことは確認済み。マージ後の clean up は別途実施推奨)。

## Test plan

- [ ] master にマージ → 次の "Release latest tag" → "Production test" 実行で deprecation warning が消えていること
- [ ] `post-test-comment (issue, 7)` / `post-test-comment (pull-request, 11)` / `dispatch-scheduled-reminder` の3ジョブが全て成功
- [ ] `abeyuya/github-actions-test` 側の `scheduled-reminder.yml` が dispatch されて起動していること