### PR TITLE
fix: catch unhandled rejection from main() in entrypoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
+import { warning } from "@actions/core";
 import { main } from "./main.js";
 
-main();
+main().catch((error: unknown) => {
+  const e = error instanceof Error ? error : undefined;
+  warning(`Unhandled error in main(): ${e?.stack ?? String(error)}`);
+});


### PR DESCRIPTION
## Summary

- `src/index.ts` で `main()` を await/catch せずに呼んでいたため、`main()` の Promise が reject すると Node 24 のデフォルト挙動 (`--unhandled-rejections=throw`) で action が exit code 1 で落ちていた。
- `.catch()` で reject を確実に拾い、`@actions/core` の `warning` で Actions log にスタックトレースを残す形に変更。
- README/issue の design intent (best-effort で通知、action は失敗させない) に従い `setFailed` は呼ばず exit code 0 のままにする。

## 受け入れ条件 (issue #346)

- [x] `main()` reject 時に unhandled promise rejection が出ない
- [x] action exit code は 0 のまま (best-effort 設計)
- [x] 失敗時に Actions log に `Unhandled error in main(): ...` warning が残る
- [x] 既存テスト pass (`npm test`: 53 passed / 1 todo)
- [x] lint pass (`npm run lint`: tsc + biome 緑)

## Test plan

- [x] `npm test`
- [x] `npm run lint`
- [ ] (手動) 無効な Slack webhook URL を設定したワークフローで unhandled rejection が出ないこと、Actions log に warning が出ることをマージ後に確認

Closes #346