### PR TITLE
fix(main): swallow Slack post failure in execPostError

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -554,7 +554,7 @@ describe("src/main", () => {
       expect(slackMock.postToSlack.mock.calls[0][0]).toEqual("dummy_url");
     });
 
-    it("does not throw when postToSlack rejects", async () => {
+    it("does not throw and logs a warning when postToSlack rejects", async () => {
       const slackMock = {
         postToSlack: vi.fn().mockRejectedValue(new Error("slack down")),
       };
@@ -562,14 +562,6 @@ describe("src/main", () => {
       await expect(
         execPostError(new Error("boom"), dummyInputs, slackMock),
       ).resolves.toBeUndefined();
-    });
-
-    it("logs a warning containing 'Failed to post error to Slack' when postToSlack rejects", async () => {
-      const slackMock = {
-        postToSlack: vi.fn().mockRejectedValue(new Error("slack down")),
-      };
-
-      await execPostError(new Error("boom"), dummyInputs, slackMock);
 
       const failureWarnings = vi
         .mocked(warning)

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,3 +1,4 @@
+import { warning } from "@actions/core";
 import type { context } from "@actions/github";
 import { vi } from "vitest";
 
@@ -6,12 +7,24 @@ import {
   arrayDiff,
   convertToSlackUsername,
   execNormalMention,
+  execPostError,
   execPrReviewRequestedMention,
   execReviewReminder,
   execReviewSubmittedMention,
 } from "../src/main.js";
 
 import { prApprovePayload } from "./fixture/real-payload-20211024-pr-approve.js";
+
+vi.mock("@actions/core", async () => {
+  const actual =
+    await vi.importActual<typeof import("@actions/core")>("@actions/core");
+  return {
+    ...actual,
+    warning: vi.fn(),
+    debug: vi.fn(),
+    setFailed: vi.fn(),
+  };
+});
 
 describe("src/main", () => {
   describe("arrayDiff", () => {
@@ -514,6 +527,59 @@ describe("src/main", () => {
       );
 
       expect(slackMock.postToSlack).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("execPostError", () => {
+    const dummyInputs: AllInputs = {
+      repoToken: "",
+      configurationPath: "",
+      slackWebhookUrl: "dummy_url",
+      iconUrl: "",
+      botName: "",
+    };
+
+    beforeEach(() => {
+      vi.mocked(warning).mockClear();
+    });
+
+    it("posts the error message to Slack when postToSlack succeeds", async () => {
+      const slackMock = {
+        postToSlack: vi.fn().mockResolvedValue("ok"),
+      };
+
+      await execPostError(new Error("boom"), dummyInputs, slackMock);
+
+      expect(slackMock.postToSlack).toHaveBeenCalledTimes(1);
+      expect(slackMock.postToSlack.mock.calls[0][0]).toEqual("dummy_url");
+    });
+
+    it("does not throw when postToSlack rejects", async () => {
+      const slackMock = {
+        postToSlack: vi.fn().mockRejectedValue(new Error("slack down")),
+      };
+
+      await expect(
+        execPostError(new Error("boom"), dummyInputs, slackMock),
+      ).resolves.toBeUndefined();
+    });
+
+    it("logs a warning containing 'Failed to post error to Slack' when postToSlack rejects", async () => {
+      const slackMock = {
+        postToSlack: vi.fn().mockRejectedValue(new Error("slack down")),
+      };
+
+      await execPostError(new Error("boom"), dummyInputs, slackMock);
+
+      const failureWarnings = vi
+        .mocked(warning)
+        .mock.calls.filter(
+          (args) =>
+            typeof args[0] === "string" &&
+            args[0].includes("Failed to post error to Slack"),
+        );
+      expect(failureWarnings.length).toBeGreaterThanOrEqual(1);
+      expect(failureWarnings[0][0]).toMatch("slack down");
     });
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -261,7 +261,14 @@ export const execPostError = async (
 
   const { slackWebhookUrl, iconUrl, botName } = allInputs;
 
-  await slackClient.postToSlack(slackWebhookUrl, message, { iconUrl, botName });
+  try {
+    await slackClient.postToSlack(slackWebhookUrl, message, {
+      iconUrl,
+      botName,
+    });
+  } catch (e) {
+    warning(`Failed to post error to Slack: ${(e as Error).message}`);
+  }
 };
 
 const getAllInputs = (): AllInputs => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -267,7 +267,8 @@ export const execPostError = async (
       botName,
     });
   } catch (e) {
-    warning(`Failed to post error to Slack: ${(e as Error).message}`);
+    const reason = e instanceof Error ? e.message : String(e);
+    warning(`Failed to post error to Slack: ${reason}`);
   }
 };
 


### PR DESCRIPTION
## Summary

- `execPostError` was awaiting `slackClient.postToSlack` without a try/catch. When the Slack webhook is invalid, rate-limited, or otherwise unreachable, the call rejected and `execPostError` itself rejected — `main()`'s catch block never ran the trailing `warning(JSON.stringify({ payload }, null, 2))` and the unhandled rejection failed the Action with exit code 1, which is the opposite of the best-effort behavior the catch block was meant to provide.
- Wrap the `postToSlack` call in try/catch and log `Failed to post error to Slack: <reason>` via `@actions/core.warning` so the action finishes successfully even when Slack is the secondary failure. Guard the caught value with `instanceof Error` so non-Error throws still produce a readable message.
- Add Vitest coverage for `execPostError` (happy path + rejection path); a top-level `vi.mock("@actions/core", ...)` with `...actual` spreads is used to spy on `warning` without affecting existing tests.

## Test plan

- [x] `npm test` (55 passed, 1 todo)
- [x] `npm run lint` (`tsc --noEmit && biome check .`)
- [x] `npm run build` (ncc)
- [x] New test: `postToSlack` rejecting with `Error("slack down")` does not cause `execPostError` to throw
- [x] New test: `warning` is called with a message containing `"Failed to post error to Slack"` and the underlying reason

Closes #345

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPYj8NG5N33gVd3RqmMpyE)_