### PR TITLE
Skip unsupported GitHub events instead of throwing (#344)

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -358,6 +358,41 @@ describe("src/main", () => {
         });
       });
     });
+
+    describe("unsupported event (issue #344)", () => {
+      it.each([
+        "closed",
+        "reopened",
+        "ready_for_review",
+        "synchronize",
+      ])("should not call postToSlack for pull_request.%s", async (action) => {
+        const slackMock = { postToSlack: vi.fn() };
+
+        const dummyPayload: Partial<typeof context.payload> = {
+          action,
+          pull_request: {
+            body: "@github_user_1 hi",
+            title: "pr_title",
+            html_url: "pr_url",
+            number: 1,
+          },
+          sender: {
+            login: "sender_github_username",
+            type: "User",
+          },
+        };
+
+        await execNormalMention(
+          dummyPayload,
+          dummyInputs,
+          dummyMapping,
+          slackMock,
+          [],
+        );
+
+        expect(slackMock.postToSlack).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe("execReviewSubmittedMention", () => {

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -359,7 +359,7 @@ describe("src/main", () => {
       });
     });
 
-    describe("unsupported event (issue #344)", () => {
+    describe("unsupported event", () => {
       it.each([
         "closed",
         "reopened",

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -480,6 +480,31 @@ describe("src/main", () => {
         expect(result).toBeNull();
       });
     });
+
+    describe("when review action is unsupported (e.g. edited / dismissed)", () => {
+      it.each([
+        "edited",
+        "dismissed",
+      ])("should not post to slack and return null for %s", async (action) => {
+        const slackMock = {
+          postToSlack: vi.fn(),
+        };
+
+        const overwritePayload = structuredClone(prApprovePayload);
+        overwritePayload.action = action;
+
+        const result = await execReviewSubmittedMention(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          overwritePayload as any,
+          dummyInputs,
+          dummyMapping,
+          slackMock,
+        );
+
+        expect(slackMock.postToSlack).not.toHaveBeenCalled();
+        expect(result).toBeNull();
+      });
+    });
   });
 
   describe("execReviewReminder", () => {

--- a/__tests__/modules/github.test.ts
+++ b/__tests__/modules/github.test.ts
@@ -1,5 +1,6 @@
 import type { context } from "@actions/github";
 import {
+  isSupportedEvent,
   pickupInfoFromGithubPayload,
   pickupUsername,
 } from "../../src/modules/github.js";
@@ -84,17 +85,18 @@ describe("modules/github", () => {
         });
       });
 
-      it("should throw error when issue deleted", () => {
-        const dummyPayload = buildIssuePayload("deleted");
+      describe("isSupportedEvent", () => {
+        it.each(["opened", "edited"])("returns true for %s", (action) => {
+          expect(isSupportedEvent(buildIssuePayload(action))).toBe(true);
+        });
 
-        try {
-          pickupInfoFromGithubPayload(dummyPayload);
-          expect.fail("expected pickupInfoFromGithubPayload to throw");
-        } catch (e: unknown) {
-          expect((e as Error).message.includes("unknown event hook:")).toEqual(
-            true,
-          );
-        }
+        it.each([
+          "deleted",
+          "closed",
+          "reopened",
+        ])("returns false for %s", (action) => {
+          expect(isSupportedEvent(buildIssuePayload(action))).toBe(false);
+        });
       });
     });
 
@@ -177,17 +179,16 @@ describe("modules/github", () => {
         });
       });
 
-      it("should throw error when issue comment deleted", () => {
-        const dummyPayload = buildIssueCommentPayload("deleted");
+      describe("isSupportedEvent", () => {
+        it.each(["created", "edited"])("returns true for %s", (action) => {
+          expect(isSupportedEvent(buildIssueCommentPayload(action))).toBe(true);
+        });
 
-        try {
-          pickupInfoFromGithubPayload(dummyPayload);
-          expect.fail("expected pickupInfoFromGithubPayload to throw");
-        } catch (e: unknown) {
-          expect((e as Error).message.includes("unknown event hook:")).toEqual(
-            true,
+        it.each(["deleted"])("returns false for %s", (action) => {
+          expect(isSupportedEvent(buildIssueCommentPayload(action))).toBe(
+            false,
           );
-        }
+        });
       });
     });
 
@@ -234,17 +235,27 @@ describe("modules/github", () => {
         });
       });
 
-      it("should throw error when pr deleted", () => {
-        const dummyPayload = buildPrPayload("deleted");
+      describe("isSupportedEvent", () => {
+        it.each([
+          "opened",
+          "edited",
+          "review_requested",
+        ])("returns true for %s", (action) => {
+          expect(isSupportedEvent(buildPrPayload(action))).toBe(true);
+        });
 
-        try {
-          pickupInfoFromGithubPayload(dummyPayload);
-          expect.fail("expected pickupInfoFromGithubPayload to throw");
-        } catch (e: unknown) {
-          expect((e as Error).message.includes("unknown event hook:")).toEqual(
-            true,
-          );
-        }
+        it.each([
+          "closed",
+          "reopened",
+          "ready_for_review",
+          "synchronize",
+          "labeled",
+          "unlabeled",
+          "assigned",
+          "unassigned",
+        ])("returns false for %s (issue #344)", (action) => {
+          expect(isSupportedEvent(buildPrPayload(action))).toBe(false);
+        });
       });
     });
 
@@ -297,17 +308,14 @@ describe("modules/github", () => {
         });
       });
 
-      it("should throw error when pull_request comment deleted", () => {
-        const dummyPayload = buildPrCommentPayload("deleted");
+      describe("isSupportedEvent", () => {
+        it.each(["created", "edited"])("returns true for %s", (action) => {
+          expect(isSupportedEvent(buildPrCommentPayload(action))).toBe(true);
+        });
 
-        try {
-          pickupInfoFromGithubPayload(dummyPayload);
-          expect.fail("expected pickupInfoFromGithubPayload to throw");
-        } catch (e: unknown) {
-          expect((e as Error).message.includes("unknown event hook:")).toEqual(
-            true,
-          );
-        }
+        it.each(["deleted"])("returns false for %s", (action) => {
+          expect(isSupportedEvent(buildPrCommentPayload(action))).toBe(false);
+        });
       });
     });
 
@@ -346,6 +354,16 @@ describe("modules/github", () => {
           senderName: "sender_github_username",
         });
       });
+
+      describe("isSupportedEvent", () => {
+        it.each(["submitted"])("returns true for %s", (action) => {
+          expect(isSupportedEvent(buildPrReviewPayload(action))).toBe(true);
+        });
+
+        it.each(["edited", "dismissed"])("returns false for %s", (action) => {
+          expect(isSupportedEvent(buildPrReviewPayload(action))).toBe(false);
+        });
+      });
     });
 
     describe("real payloat test 20211017", () => {
@@ -363,6 +381,16 @@ describe("modules/github", () => {
         expect(result.senderName).toEqual("abeyuya");
         expect(result.body).toEqual("approve comment");
       });
+    });
+  });
+
+  describe("isSupportedEvent edge cases", () => {
+    it("returns false when action is missing", () => {
+      expect(isSupportedEvent({})).toBe(false);
+    });
+
+    it("returns false when neither issue nor pull_request is present", () => {
+      expect(isSupportedEvent({ action: "opened" })).toBe(false);
     });
   });
 });

--- a/__tests__/modules/github.test.ts
+++ b/__tests__/modules/github.test.ts
@@ -253,7 +253,7 @@ describe("modules/github", () => {
           "unlabeled",
           "assigned",
           "unassigned",
-        ])("returns false for %s (issue #344)", (action) => {
+        ])("returns false for %s", (action) => {
           expect(isSupportedEvent(buildPrPayload(action))).toBe(false);
         });
       });

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { debug, getInput, setFailed, warning } from "@actions/core";
 import { context, getOctokit } from "@actions/github";
 
 import {
+  isSupportedEvent,
   needToSendReviewSubmittedMention,
   pickupInfoFromGithubPayload,
   pickupUsername,
@@ -111,6 +112,11 @@ export const execNormalMention = async (
   slackClient: Pick<typeof SlackRepositoryImpl, "postToSlack">,
   ignoreSlackIds: string[],
 ): Promise<void> => {
+  if (!isSupportedEvent(payload)) {
+    debug("finish execNormalMention because event is not supported");
+    return;
+  }
+
   const info = pickupInfoFromGithubPayload(payload);
 
   if (info.body === null) {
@@ -158,6 +164,11 @@ export const execReviewSubmittedMention = async (
 ): Promise<string | null> => {
   if (!needToSendReviewSubmittedMention(payload)) {
     throw new Error("failed to parse payload");
+  }
+
+  if (!isSupportedEvent(payload)) {
+    debug("finish execReviewSubmittedMention because event is not supported");
+    return null;
   }
 
   const prOwnerGithubUsername = payload.pull_request?.user?.login;

--- a/src/modules/github.ts
+++ b/src/modules/github.ts
@@ -104,6 +104,6 @@ export const pickupInfoFromGithubPayload = (
   }
 
   throw new Error(
-    "pickupInfoFromGithubPayload called with unsupported payload. Guard with isSupportedEvent() before calling.",
+    `pickupInfoFromGithubPayload called with unsupported payload. Guard with isSupportedEvent() before calling. payload=${JSON.stringify(payload)}`,
   );
 };

--- a/src/modules/github.ts
+++ b/src/modules/github.ts
@@ -29,7 +29,7 @@ const eventCategoryOf = (
   }
   if (payload.pull_request) {
     if (payload.review) return "pull_request_review";
-    if (payload.comment) return "issue_comment";
+    if (payload.comment) return "pull_request_review_comment";
     return "pull_request";
   }
   return null;

--- a/src/modules/github.ts
+++ b/src/modules/github.ts
@@ -21,10 +21,27 @@ const acceptActionTypes = {
   pull_request_review_comment: ["created", "edited"],
 };
 
-const buildError = (payload: unknown): Error => {
-  return new Error(
-    `unknown event hook: ${JSON.stringify(payload, undefined, 2)}`,
-  );
+const eventCategoryOf = (
+  payload: Partial<typeof context.payload>,
+): keyof typeof acceptActionTypes | null => {
+  if (payload.issue) {
+    return payload.comment ? "issue_comment" : "issues";
+  }
+  if (payload.pull_request) {
+    if (payload.review) return "pull_request_review";
+    if (payload.comment) return "issue_comment";
+    return "pull_request";
+  }
+  return null;
+};
+
+export const isSupportedEvent = (
+  payload: Partial<typeof context.payload>,
+): boolean => {
+  const category = eventCategoryOf(payload);
+  if (category === null) return false;
+  if (typeof payload.action !== "string") return false;
+  return acceptActionTypes[category].includes(payload.action);
 };
 
 export const needToSendReviewSubmittedMention = (
@@ -41,28 +58,14 @@ export const pickupInfoFromGithubPayload = (
   url: string;
   senderName: string;
 } => {
-  const { action } = payload;
-
-  if (action === undefined) {
-    throw buildError(payload);
-  }
-
   if (payload.issue) {
     if (payload.comment) {
-      if (!acceptActionTypes.issue_comment.includes(action)) {
-        throw buildError(payload);
-      }
-
       return {
         body: payload.comment.body,
         title: payload.issue.title,
         url: payload.comment.html_url,
         senderName: payload.sender?.login || "",
       };
-    }
-
-    if (!acceptActionTypes.issues.includes(action)) {
-      throw buildError(payload);
     }
 
     return {
@@ -75,10 +78,6 @@ export const pickupInfoFromGithubPayload = (
 
   if (payload.pull_request) {
     if (payload.review) {
-      if (!acceptActionTypes.pull_request_review.includes(action)) {
-        throw buildError(payload);
-      }
-
       return {
         body: payload.review.body,
         title: payload.pull_request?.title || "",
@@ -88,20 +87,12 @@ export const pickupInfoFromGithubPayload = (
     }
 
     if (payload.comment) {
-      if (!acceptActionTypes.issue_comment.includes(action)) {
-        throw buildError(payload);
-      }
-
       return {
         body: payload.comment.body,
         title: payload.pull_request.title,
         url: payload.comment.html_url,
         senderName: payload.sender?.login || "",
       };
-    }
-
-    if (!acceptActionTypes.pull_request.includes(action)) {
-      throw buildError(payload);
     }
 
     return {
@@ -112,5 +103,7 @@ export const pickupInfoFromGithubPayload = (
     };
   }
 
-  throw buildError(payload);
+  throw new Error(
+    "pickupInfoFromGithubPayload called with unsupported payload. Guard with isSupportedEvent() before calling.",
+  );
 };


### PR DESCRIPTION
## Summary

`pickupInfoFromGithubPayload` was throwing whenever a GitHub action was not in `acceptActionTypes` (e.g. `pull_request.closed` / `reopened` / `ready_for_review` / `synchronize`). The thrown error bubbled up to `main()`'s catch and posted a noisy `unknown event hook` payload dump to Slack whenever a user widened their `on.pull_request.types`.

This PR introduces `isSupportedEvent(payload)` as the single owner of the whitelist check, called at the entry of each exec function. `pickupInfoFromGithubPayload` now focuses on value extraction; the trailing `throw` remains only as an invariant-violation guard for direct callers that forget to gate with `isSupportedEvent`.

### Changes

- `src/modules/github.ts`
  - Add private `eventCategoryOf` and public `isSupportedEvent`
  - Remove `buildError` and all per-branch whitelist throws inside `pickupInfoFromGithubPayload`
  - Keep one invariant-violation throw at the end (includes payload for debuggability)
- `src/main.ts`
  - Guard `execNormalMention` and `execReviewSubmittedMention` with `isSupportedEvent` at the top; silently early-return on unsupported events
- Tests: replace the four `should throw error when X deleted` cases with `isSupportedEvent` `it.each` tables, cover the `pull_request` actions called out in #344 (`closed` / `reopened` / `ready_for_review` / `synchronize` / `labeled` / `unlabeled` / `assigned` / `unassigned`), and add unsupported-event tests for both `execNormalMention` and `execReviewSubmittedMention`

Closes #344

## Test plan

- [x] `npm test` (vitest, 82 passed)
- [x] `npm run lint` (tsc --noEmit && biome check)
- [x] `npm run build` (ncc)
- [ ] Manual smoke test: run a workflow with `on.pull_request.types: [opened, closed]`, confirm `opened` still mentions and `closed` posts nothing to Slack

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqSky98UCbwL2vPkLhYNc4)_