### PR TITLE
Enrich scheduled-reminder Slack notifications (#351)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,30 @@ jobs:
 
 When invoked with `type: scheduled-reminder`, this action queries the open pull requests in the repository and posts a single aggregated Slack message listing each pending reviewer and the pull requests waiting on them. Users that appear in the mapping YAML are mentioned with `<@slack_id>` (or `<!subteam^id>` for teams); users not in the mapping are listed by their GitHub username.
 
+Each pull-request entry includes:
+
+- PR number and title (linked)
+- Time since the PR was opened (e.g. `3d`, `5h`)
+- Current approval state: `:white_check_mark: approved`, `:warning: changes requested`, or `:hourglass_flowing_sand: review required`
+- Labels attached to the PR (up to 5; the rest are summarized as `, +N more`)
+
+The notification is delivered as a Slack Block Kit message with a plain-text fallback, so it renders well in modern Slack clients and degrades gracefully where Block Kit is unavailable.
+
+Example rendering (text fallback):
+
+```
+:eyes: Pending review reminders for `owner/repo`:
+
+<@U_ALICE>
+• <https://github.com/owner/repo/pull/123|#123 Fix login bug>
+_3d • :warning: changes requested • `bug`, `priority-high`_
+• <https://github.com/owner/repo/pull/130|#130 Refactor auth>
+_5h • :hourglass_flowing_sand: review required_
+```
+
 - Draft pull requests are excluded.
 - If there are no pending review requests, nothing is posted.
+- Approval state is fetched via the `pulls.listReviews` API for each PR with pending reviewers. Calls are made in chunks of 5 to stay friendly to API rate limits.
 
 .github/workflows/review-reminder.yml
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -529,10 +529,22 @@ describe("src/main", () => {
       botName: "",
     };
 
-    const buildOctokit = (prs: unknown[]) =>
+    const buildOctokit = (
+      prs: unknown[],
+      reviewsByPr: Record<number, unknown[]> = {},
+    ) =>
       ({
         paginate: vi.fn(async () => prs),
-        rest: { pulls: { list: vi.fn() } },
+        rest: {
+          pulls: {
+            list: vi.fn(),
+            listReviews: vi.fn(
+              async ({ pull_number }: { pull_number: number }) => ({
+                data: reviewsByPr[pull_number] ?? [],
+              }),
+            ),
+          },
+        },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       }) as any;
 
@@ -540,9 +552,12 @@ describe("src/main", () => {
       const slackMock = { postToSlack: vi.fn() };
       const octokit = buildOctokit([
         {
+          number: 42,
           title: "PR1",
           html_url: "https://example.com/pr/1",
           draft: false,
+          created_at: "2026-05-14T12:00:00Z",
+          labels: [{ name: "bug" }],
           requested_reviewers: [{ login: "github_user_1" }, { login: "ghost" }],
           requested_teams: [],
         },
@@ -562,16 +577,23 @@ describe("src/main", () => {
       expect(call[0]).toEqual("dummy_url");
       expect(call[1]).toMatch("<@slack_user_1>");
       expect(call[1]).toMatch("`ghost`");
-      expect(call[1]).toMatch("<https://example.com/pr/1|PR1>");
+      expect(call[1]).toMatch("<https://example.com/pr/1|#42 PR1>");
+      expect(call[2]).toMatchObject({
+        blocks: expect.any(Array),
+      });
+      expect(call[2].blocks.length).toBeGreaterThan(0);
     });
 
     it("does not post when there are no pending reviews", async () => {
       const slackMock = { postToSlack: vi.fn() };
       const octokit = buildOctokit([
         {
+          number: 9,
           title: "PR without reviewers",
           html_url: "https://example.com/pr/9",
           draft: false,
+          created_at: "2026-05-17T12:00:00Z",
+          labels: [],
           requested_reviewers: [],
           requested_teams: [],
         },

--- a/__tests__/modules/reviewReminder.test.ts
+++ b/__tests__/modules/reviewReminder.test.ts
@@ -1,31 +1,192 @@
 import { vi } from "vitest";
 
 import {
+  aggregateApprovalState,
   buildReviewReminderMessage,
   fetchOpenReviewRequests,
+  formatLabels,
+  formatRelativeAge,
   type ReminderEntry,
 } from "../../src/modules/reviewReminder.js";
 
+const FIXED_NOW = new Date("2026-05-17T12:00:00Z");
+
+const makePr = (overrides: Record<string, unknown> = {}) => ({
+  number: 1,
+  title: "PR title",
+  html_url: "https://example.com/pr/1",
+  draft: false,
+  created_at: "2026-05-14T12:00:00Z",
+  labels: [],
+  requested_reviewers: [],
+  requested_teams: [],
+  ...overrides,
+});
+
+const makeEntryPr = (overrides: Record<string, unknown> = {}) => ({
+  number: 1,
+  title: "PR title",
+  url: "https://example.com/pr/1",
+  createdAt: "2026-05-14T12:00:00Z",
+  approvalState: "review_required" as const,
+  labels: [],
+  ...overrides,
+});
+
 describe("reviewReminder", () => {
-  describe("buildReviewReminderMessage", () => {
-    it("returns null when entries are empty", () => {
-      expect(buildReviewReminderMessage([], "owner/repo")).toBeNull();
+  describe("formatRelativeAge", () => {
+    it("returns 'just now' for very recent timestamps", () => {
+      expect(
+        formatRelativeAge(new Date("2026-05-17T11:59:30Z"), FIXED_NOW),
+      ).toBe("just now");
     });
 
-    it("renders mapped user with <@id>", () => {
+    it("returns minutes for sub-hour ages", () => {
+      expect(
+        formatRelativeAge(new Date("2026-05-17T11:57:00Z"), FIXED_NOW),
+      ).toBe("3m");
+    });
+
+    it("returns hours for sub-day ages", () => {
+      expect(
+        formatRelativeAge(new Date("2026-05-17T07:00:00Z"), FIXED_NOW),
+      ).toBe("5h");
+    });
+
+    it("returns days for multi-day ages", () => {
+      expect(
+        formatRelativeAge(new Date("2026-05-14T12:00:00Z"), FIXED_NOW),
+      ).toBe("3d");
+    });
+
+    it("returns 'just now' when createdAt is in the future", () => {
+      expect(
+        formatRelativeAge(new Date("2026-05-17T13:00:00Z"), FIXED_NOW),
+      ).toBe("just now");
+    });
+  });
+
+  describe("formatLabels", () => {
+    it("returns empty string for no labels", () => {
+      expect(formatLabels([])).toBe("");
+    });
+
+    it("renders all labels when at or below the display limit", () => {
+      expect(formatLabels(["bug", "ui", "priority-high"])).toBe(
+        "`bug`, `ui`, `priority-high`",
+      );
+    });
+
+    it("truncates extra labels with a +N more suffix", () => {
+      expect(formatLabels(["a", "b", "c", "d", "e", "f", "g"])).toBe(
+        "`a`, `b`, `c`, `d`, `e`, +2 more",
+      );
+    });
+  });
+
+  describe("aggregateApprovalState", () => {
+    it("returns review_required when there are no reviews", () => {
+      expect(aggregateApprovalState([])).toBe("review_required");
+    });
+
+    it("returns approved when the only reviewer approved", () => {
+      expect(
+        aggregateApprovalState([{ user: { login: "a" }, state: "APPROVED" }]),
+      ).toBe("approved");
+    });
+
+    it("returns approved when all reviewers approved", () => {
+      expect(
+        aggregateApprovalState([
+          { user: { login: "a" }, state: "APPROVED" },
+          { user: { login: "b" }, state: "APPROVED" },
+        ]),
+      ).toBe("approved");
+    });
+
+    it("returns changes_requested when any reviewer requested changes", () => {
+      expect(
+        aggregateApprovalState([
+          { user: { login: "a" }, state: "APPROVED" },
+          { user: { login: "b" }, state: "CHANGES_REQUESTED" },
+        ]),
+      ).toBe("changes_requested");
+    });
+
+    it("uses the latest state when a reviewer submitted multiple reviews", () => {
+      expect(
+        aggregateApprovalState([
+          { user: { login: "a" }, state: "COMMENTED" },
+          { user: { login: "a" }, state: "APPROVED" },
+        ]),
+      ).toBe("approved");
+
+      expect(
+        aggregateApprovalState([
+          { user: { login: "a" }, state: "APPROVED" },
+          { user: { login: "a" }, state: "CHANGES_REQUESTED" },
+        ]),
+      ).toBe("changes_requested");
+    });
+
+    it("ignores COMMENTED-only reviews as no decision", () => {
+      expect(
+        aggregateApprovalState([{ user: { login: "a" }, state: "COMMENTED" }]),
+      ).toBe("review_required");
+    });
+  });
+
+  describe("buildReviewReminderMessage", () => {
+    it("returns null when entries are empty", () => {
+      expect(
+        buildReviewReminderMessage([], "owner/repo", FIXED_NOW),
+      ).toBeNull();
+    });
+
+    it("renders mapped user with <@id> and PR metadata", () => {
       const entries: ReminderEntry[] = [
         {
           githubName: "alice",
           slackId: "U_ALICE",
           isTeam: false,
-          prs: [{ title: "Fix bug", url: "https://example.com/pr/1" }],
+          prs: [
+            makeEntryPr({
+              number: 123,
+              title: "Fix bug",
+              url: "https://example.com/pr/123",
+              approvalState: "approved",
+              labels: ["bug", "priority-high"],
+            }),
+          ],
         },
       ];
 
-      const msg = buildReviewReminderMessage(entries, "owner/repo");
-      expect(msg).toContain("owner/repo");
-      expect(msg).toContain("<@U_ALICE>");
-      expect(msg).toContain("• <https://example.com/pr/1|Fix bug>");
+      const result = buildReviewReminderMessage(
+        entries,
+        "owner/repo",
+        FIXED_NOW,
+      );
+      expect(result).not.toBeNull();
+      const { text, blocks } = result!;
+
+      expect(text).toContain("owner/repo");
+      expect(text).toContain("<@U_ALICE>");
+      expect(text).toContain("<https://example.com/pr/123|#123 Fix bug>");
+      expect(text).toContain("3d");
+      expect(text).toContain(":white_check_mark:");
+      expect(text).toContain("approved");
+      expect(text).toContain("`bug`");
+      expect(text).toContain("`priority-high`");
+
+      expect(blocks[0]).toEqual({
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: ":eyes: Pending review reminders for `owner/repo`:",
+        },
+      });
+      expect(blocks[1]).toEqual({ type: "divider" });
+      expect(blocks).toHaveLength(3);
     });
 
     it("renders mapped team with <!subteam^id>", () => {
@@ -34,13 +195,23 @@ describe("reviewReminder", () => {
           githubName: "team-a",
           slackId: "S_TEAM",
           isTeam: true,
-          prs: [{ title: "Feature X", url: "https://example.com/pr/2" }],
+          prs: [
+            makeEntryPr({
+              number: 2,
+              title: "Feature X",
+              url: "https://example.com/pr/2",
+            }),
+          ],
         },
       ];
 
-      const msg = buildReviewReminderMessage(entries, "owner/repo");
-      expect(msg).toContain("<!subteam^S_TEAM>");
-      expect(msg).toContain("• <https://example.com/pr/2|Feature X>");
+      const result = buildReviewReminderMessage(
+        entries,
+        "owner/repo",
+        FIXED_NOW,
+      );
+      expect(result!.text).toContain("<!subteam^S_TEAM>");
+      expect(result!.text).toContain("<https://example.com/pr/2|#2 Feature X>");
     });
 
     it("renders unmapped user with backticked github name", () => {
@@ -48,73 +219,191 @@ describe("reviewReminder", () => {
         {
           githubName: "bob",
           isTeam: false,
-          prs: [{ title: "Tweak", url: "https://example.com/pr/3" }],
+          prs: [makeEntryPr({ number: 3, title: "Tweak" })],
         },
       ];
 
-      const msg = buildReviewReminderMessage(entries, "owner/repo");
-      expect(msg).toContain("`bob`");
-      expect(msg).not.toContain("<@");
+      const result = buildReviewReminderMessage(
+        entries,
+        "owner/repo",
+        FIXED_NOW,
+      );
+      expect(result!.text).toContain("`bob`");
+      expect(result!.text).not.toContain("<@");
     });
 
-    it("aggregates multiple PRs per reviewer", () => {
+    it("renders distinct approval state emoji and label", () => {
       const entries: ReminderEntry[] = [
         {
           githubName: "alice",
           slackId: "U_ALICE",
           isTeam: false,
           prs: [
-            { title: "Fix 1", url: "https://example.com/pr/1" },
-            { title: "Fix 2", url: "https://example.com/pr/2" },
+            makeEntryPr({
+              number: 10,
+              approvalState: "approved",
+              url: "https://example.com/pr/10",
+            }),
+            makeEntryPr({
+              number: 11,
+              approvalState: "changes_requested",
+              url: "https://example.com/pr/11",
+            }),
+            makeEntryPr({
+              number: 12,
+              approvalState: "review_required",
+              url: "https://example.com/pr/12",
+            }),
           ],
         },
       ];
 
-      const msg = buildReviewReminderMessage(entries, "owner/repo") ?? "";
-      expect(msg).toContain("<https://example.com/pr/1|Fix 1>");
-      expect(msg).toContain("<https://example.com/pr/2|Fix 2>");
+      const { text } = buildReviewReminderMessage(
+        entries,
+        "owner/repo",
+        FIXED_NOW,
+      )!;
+
+      expect(text).toContain(":white_check_mark: approved");
+      expect(text).toContain(":warning: changes requested");
+      expect(text).toContain(":hourglass_flowing_sand: review required");
+    });
+
+    it("truncates long label lists with +N more", () => {
+      const entries: ReminderEntry[] = [
+        {
+          githubName: "alice",
+          isTeam: false,
+          prs: [
+            makeEntryPr({
+              labels: ["a", "b", "c", "d", "e", "f", "g"],
+            }),
+          ],
+        },
+      ];
+
+      const { text } = buildReviewReminderMessage(
+        entries,
+        "owner/repo",
+        FIXED_NOW,
+      )!;
+      expect(text).toContain("+2 more");
+    });
+
+    it("emits one section block per reviewer entry plus header and divider", () => {
+      const entries: ReminderEntry[] = [
+        {
+          githubName: "alice",
+          slackId: "U_ALICE",
+          isTeam: false,
+          prs: [makeEntryPr({ number: 1 })],
+        },
+        {
+          githubName: "bob",
+          isTeam: false,
+          prs: [makeEntryPr({ number: 2, url: "https://example.com/pr/2" })],
+        },
+      ];
+
+      const { blocks } = buildReviewReminderMessage(
+        entries,
+        "owner/repo",
+        FIXED_NOW,
+      )!;
+      expect(blocks).toHaveLength(4);
+      expect(blocks[2]).toMatchObject({
+        type: "section",
+        text: { type: "mrkdwn" },
+      });
+      expect(blocks[3]).toMatchObject({
+        type: "section",
+        text: { type: "mrkdwn" },
+      });
     });
   });
 
   describe("fetchOpenReviewRequests", () => {
-    const buildOctokit = (prs: unknown[]) =>
-      ({
-        paginate: vi.fn(async () => prs),
-        rest: { pulls: { list: vi.fn() } },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      }) as any;
+    const buildOctokit = (
+      prs: unknown[],
+      reviewsByPr: Record<number, unknown[]> = {},
+    ) => {
+      const listReviews = vi.fn(
+        async ({ pull_number }: { pull_number: number }) => ({
+          data: reviewsByPr[pull_number] ?? [],
+        }),
+      );
+      return {
+        client: {
+          paginate: vi.fn(async () => prs),
+          rest: { pulls: { list: vi.fn(), listReviews } },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        listReviews,
+      };
+    };
 
-    it("groups reviewers across PRs and skips drafts", async () => {
-      const octokit = buildOctokit([
+    it("groups reviewers across PRs, skips drafts, and attaches approval state", async () => {
+      const { client, listReviews } = buildOctokit(
+        [
+          makePr({
+            number: 1,
+            title: "PR1",
+            html_url: "https://example.com/pr/1",
+            created_at: "2026-05-14T12:00:00Z",
+            labels: [{ name: "bug" }, { name: "ui" }],
+            requested_reviewers: [{ login: "alice" }, { login: "bob" }],
+          }),
+          makePr({
+            number: 2,
+            title: "PR2",
+            html_url: "https://example.com/pr/2",
+            created_at: "2026-05-17T07:00:00Z",
+            labels: [],
+            requested_reviewers: [{ login: "alice" }],
+            requested_teams: [{ name: "team-a" }],
+          }),
+          makePr({
+            number: 3,
+            title: "Draft PR",
+            html_url: "https://example.com/pr/3",
+            draft: true,
+            requested_reviewers: [{ login: "carol" }],
+          }),
+          makePr({
+            number: 4,
+            title: "No reviewers",
+            html_url: "https://example.com/pr/4",
+            requested_reviewers: [],
+            requested_teams: [],
+          }),
+        ],
         {
-          title: "PR1",
-          html_url: "https://example.com/pr/1",
-          draft: false,
-          requested_reviewers: [{ login: "alice" }, { login: "bob" }],
-          requested_teams: [],
+          1: [{ user: { login: "x" }, state: "APPROVED" }],
+          2: [{ user: { login: "y" }, state: "CHANGES_REQUESTED" }],
         },
-        {
-          title: "PR2",
-          html_url: "https://example.com/pr/2",
-          draft: false,
-          requested_reviewers: [{ login: "alice" }],
-          requested_teams: [{ name: "team-a" }],
-        },
-        {
-          title: "Draft PR",
-          html_url: "https://example.com/pr/3",
-          draft: true,
-          requested_reviewers: [{ login: "carol" }],
-          requested_teams: [],
-        },
-      ]);
+      );
 
-      const result = await fetchOpenReviewRequests(octokit, "owner", "repo");
+      const result = await fetchOpenReviewRequests(client, "owner", "repo");
+
+      // draft / レビュアーなし PR は listReviews を呼ばない
+      expect(listReviews).toHaveBeenCalledTimes(2);
 
       const byName = Object.fromEntries(result.map((r) => [r.githubName, r]));
 
       expect(byName.alice.isTeam).toBe(false);
       expect(byName.alice.prs).toHaveLength(2);
+
+      const pr1 = byName.alice.prs.find((p) => p.number === 1)!;
+      expect(pr1.title).toBe("PR1");
+      expect(pr1.url).toBe("https://example.com/pr/1");
+      expect(pr1.createdAt).toBe("2026-05-14T12:00:00Z");
+      expect(pr1.approvalState).toBe("approved");
+      expect(pr1.labels).toEqual(["bug", "ui"]);
+
+      const pr2 = byName.alice.prs.find((p) => p.number === 2)!;
+      expect(pr2.approvalState).toBe("changes_requested");
+      expect(pr2.labels).toEqual([]);
+
       expect(byName.bob.prs).toHaveLength(1);
       expect(byName["team-a"].isTeam).toBe(true);
       expect(byName["team-a"].prs).toHaveLength(1);
@@ -122,18 +411,13 @@ describe("reviewReminder", () => {
     });
 
     it("returns empty array when no PRs have reviewers", async () => {
-      const octokit = buildOctokit([
-        {
-          title: "PR1",
-          html_url: "https://example.com/pr/1",
-          draft: false,
-          requested_reviewers: [],
-          requested_teams: [],
-        },
+      const { client, listReviews } = buildOctokit([
+        makePr({ requested_reviewers: [], requested_teams: [] }),
       ]);
 
-      const result = await fetchOpenReviewRequests(octokit, "owner", "repo");
+      const result = await fetchOpenReviewRequests(client, "owner", "repo");
       expect(result).toEqual([]);
+      expect(listReviews).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/modules/reviewReminder.test.ts
+++ b/__tests__/modules/reviewReminder.test.ts
@@ -86,102 +86,69 @@ describe("reviewReminder", () => {
 
   describe("aggregateApprovalState", () => {
     it("returns review_required when there are no reviews", () => {
-      expect(aggregateApprovalState([], false)).toBe("review_required");
+      expect(aggregateApprovalState([])).toBe("review_required");
     });
 
-    it("returns approved when the only reviewer approved and nothing is pending", () => {
+    it("returns approved when the only reviewer approved", () => {
       expect(
-        aggregateApprovalState(
-          [{ user: { login: "a" }, state: "APPROVED" }],
-          false,
-        ),
+        aggregateApprovalState([{ user: { login: "a" }, state: "APPROVED" }]),
       ).toBe("approved");
-    });
-
-    it("downgrades approved to review_required when reviewers are still pending", () => {
-      expect(
-        aggregateApprovalState(
-          [{ user: { login: "a" }, state: "APPROVED" }],
-          true,
-        ),
-      ).toBe("review_required");
     });
 
     it("returns approved when all reviewers approved", () => {
       expect(
-        aggregateApprovalState(
-          [
-            { user: { login: "a" }, state: "APPROVED" },
-            { user: { login: "b" }, state: "APPROVED" },
-          ],
-          false,
-        ),
+        aggregateApprovalState([
+          { user: { login: "a" }, state: "APPROVED" },
+          { user: { login: "b" }, state: "APPROVED" },
+        ]),
       ).toBe("approved");
     });
 
-    it("returns changes_requested when any reviewer requested changes, even with pending", () => {
+    it("returns changes_requested when any reviewer requested changes", () => {
       expect(
-        aggregateApprovalState(
-          [
-            { user: { login: "a" }, state: "APPROVED" },
-            { user: { login: "b" }, state: "CHANGES_REQUESTED" },
-          ],
-          true,
-        ),
+        aggregateApprovalState([
+          { user: { login: "a" }, state: "APPROVED" },
+          { user: { login: "b" }, state: "CHANGES_REQUESTED" },
+        ]),
       ).toBe("changes_requested");
     });
 
     it("uses the latest state when a reviewer submitted multiple reviews", () => {
       expect(
-        aggregateApprovalState(
-          [
-            { user: { login: "a" }, state: "COMMENTED" },
-            { user: { login: "a" }, state: "APPROVED" },
-          ],
-          false,
-        ),
+        aggregateApprovalState([
+          { user: { login: "a" }, state: "COMMENTED" },
+          { user: { login: "a" }, state: "APPROVED" },
+        ]),
       ).toBe("approved");
 
       expect(
-        aggregateApprovalState(
-          [
-            { user: { login: "a" }, state: "APPROVED" },
-            { user: { login: "a" }, state: "CHANGES_REQUESTED" },
-          ],
-          false,
-        ),
+        aggregateApprovalState([
+          { user: { login: "a" }, state: "APPROVED" },
+          { user: { login: "a" }, state: "CHANGES_REQUESTED" },
+        ]),
       ).toBe("changes_requested");
     });
 
     it("treats DISMISSED as invalidating the prior decision", () => {
       expect(
-        aggregateApprovalState(
-          [
-            { user: { login: "a" }, state: "CHANGES_REQUESTED" },
-            { user: { login: "a" }, state: "DISMISSED" },
-          ],
-          false,
-        ),
+        aggregateApprovalState([
+          { user: { login: "a" }, state: "CHANGES_REQUESTED" },
+          { user: { login: "a" }, state: "DISMISSED" },
+        ]),
       ).toBe("review_required");
 
       expect(
-        aggregateApprovalState(
-          [
-            { user: { login: "a" }, state: "APPROVED" },
-            { user: { login: "a" }, state: "DISMISSED" },
-            { user: { login: "b" }, state: "APPROVED" },
-          ],
-          false,
-        ),
+        aggregateApprovalState([
+          { user: { login: "a" }, state: "APPROVED" },
+          { user: { login: "a" }, state: "DISMISSED" },
+          { user: { login: "b" }, state: "APPROVED" },
+        ]),
       ).toBe("approved");
     });
 
     it("ignores COMMENTED-only reviews as no decision", () => {
       expect(
-        aggregateApprovalState(
-          [{ user: { login: "a" }, state: "COMMENTED" }],
-          false,
-        ),
+        aggregateApprovalState([{ user: { login: "a" }, state: "COMMENTED" }]),
       ).toBe("review_required");
     });
   });
@@ -478,12 +445,14 @@ describe("reviewReminder", () => {
     });
 
     it("falls back to review_required when listReviews throws for a PR", async () => {
-      const listReviews = vi
-        .fn()
-        .mockRejectedValueOnce(new Error("rate limit"))
-        .mockResolvedValueOnce({
-          data: [{ user: { login: "x" }, state: "APPROVED" }],
-        });
+      const listReviews = vi.fn(
+        async ({ pull_number }: { pull_number: number }) => {
+          if (pull_number === 1) throw new Error("rate limit");
+          return {
+            data: [{ user: { login: "x" }, state: "CHANGES_REQUESTED" }],
+          };
+        },
+      );
       const client = {
         paginate: vi.fn(async () => [
           makePr({
@@ -502,10 +471,14 @@ describe("reviewReminder", () => {
       const result = await fetchOpenReviewRequests(client, "owner", "repo");
       const alice = result.find((r) => r.githubName === "alice");
       assert(alice);
-      // どちらの PR の listReviews が先に呼ばれるかは並列実行で順不同なため、
-      // 失敗側が review_required にフォールバックしていることだけを確認する
-      const states = alice.prs.map((p) => p.approvalState).sort();
-      expect(states).toEqual(["review_required", "review_required"]);
+
+      const pr1 = alice.prs.find((p) => p.number === 1);
+      assert(pr1);
+      expect(pr1.approvalState).toBe("review_required");
+
+      const pr2 = alice.prs.find((p) => p.number === 2);
+      assert(pr2);
+      expect(pr2.approvalState).toBe("changes_requested");
     });
   });
 

--- a/__tests__/modules/reviewReminder.test.ts
+++ b/__tests__/modules/reviewReminder.test.ts
@@ -86,52 +86,102 @@ describe("reviewReminder", () => {
 
   describe("aggregateApprovalState", () => {
     it("returns review_required when there are no reviews", () => {
-      expect(aggregateApprovalState([])).toBe("review_required");
+      expect(aggregateApprovalState([], false)).toBe("review_required");
     });
 
-    it("returns approved when the only reviewer approved", () => {
+    it("returns approved when the only reviewer approved and nothing is pending", () => {
       expect(
-        aggregateApprovalState([{ user: { login: "a" }, state: "APPROVED" }]),
+        aggregateApprovalState(
+          [{ user: { login: "a" }, state: "APPROVED" }],
+          false,
+        ),
       ).toBe("approved");
+    });
+
+    it("downgrades approved to review_required when reviewers are still pending", () => {
+      expect(
+        aggregateApprovalState(
+          [{ user: { login: "a" }, state: "APPROVED" }],
+          true,
+        ),
+      ).toBe("review_required");
     });
 
     it("returns approved when all reviewers approved", () => {
       expect(
-        aggregateApprovalState([
-          { user: { login: "a" }, state: "APPROVED" },
-          { user: { login: "b" }, state: "APPROVED" },
-        ]),
+        aggregateApprovalState(
+          [
+            { user: { login: "a" }, state: "APPROVED" },
+            { user: { login: "b" }, state: "APPROVED" },
+          ],
+          false,
+        ),
       ).toBe("approved");
     });
 
-    it("returns changes_requested when any reviewer requested changes", () => {
+    it("returns changes_requested when any reviewer requested changes, even with pending", () => {
       expect(
-        aggregateApprovalState([
-          { user: { login: "a" }, state: "APPROVED" },
-          { user: { login: "b" }, state: "CHANGES_REQUESTED" },
-        ]),
+        aggregateApprovalState(
+          [
+            { user: { login: "a" }, state: "APPROVED" },
+            { user: { login: "b" }, state: "CHANGES_REQUESTED" },
+          ],
+          true,
+        ),
       ).toBe("changes_requested");
     });
 
     it("uses the latest state when a reviewer submitted multiple reviews", () => {
       expect(
-        aggregateApprovalState([
-          { user: { login: "a" }, state: "COMMENTED" },
-          { user: { login: "a" }, state: "APPROVED" },
-        ]),
+        aggregateApprovalState(
+          [
+            { user: { login: "a" }, state: "COMMENTED" },
+            { user: { login: "a" }, state: "APPROVED" },
+          ],
+          false,
+        ),
       ).toBe("approved");
 
       expect(
-        aggregateApprovalState([
-          { user: { login: "a" }, state: "APPROVED" },
-          { user: { login: "a" }, state: "CHANGES_REQUESTED" },
-        ]),
+        aggregateApprovalState(
+          [
+            { user: { login: "a" }, state: "APPROVED" },
+            { user: { login: "a" }, state: "CHANGES_REQUESTED" },
+          ],
+          false,
+        ),
       ).toBe("changes_requested");
+    });
+
+    it("treats DISMISSED as invalidating the prior decision", () => {
+      expect(
+        aggregateApprovalState(
+          [
+            { user: { login: "a" }, state: "CHANGES_REQUESTED" },
+            { user: { login: "a" }, state: "DISMISSED" },
+          ],
+          false,
+        ),
+      ).toBe("review_required");
+
+      expect(
+        aggregateApprovalState(
+          [
+            { user: { login: "a" }, state: "APPROVED" },
+            { user: { login: "a" }, state: "DISMISSED" },
+            { user: { login: "b" }, state: "APPROVED" },
+          ],
+          false,
+        ),
+      ).toBe("approved");
     });
 
     it("ignores COMMENTED-only reviews as no decision", () => {
       expect(
-        aggregateApprovalState([{ user: { login: "a" }, state: "COMMENTED" }]),
+        aggregateApprovalState(
+          [{ user: { login: "a" }, state: "COMMENTED" }],
+          false,
+        ),
       ).toBe("review_required");
     });
   });
@@ -402,7 +452,8 @@ describe("reviewReminder", () => {
       expect(pr1.title).toBe("PR1");
       expect(pr1.url).toBe("https://example.com/pr/1");
       expect(pr1.createdAt).toBe("2026-05-14T12:00:00Z");
-      expect(pr1.approvalState).toBe("approved");
+      // alice / bob が pending として残るため、x の APPROVED だけでは approved にならない
+      expect(pr1.approvalState).toBe("review_required");
       expect(pr1.labels).toEqual(["bug", "ui"]);
 
       const pr2 = byName.alice.prs.find((p) => p.number === 2);
@@ -424,6 +475,78 @@ describe("reviewReminder", () => {
       const result = await fetchOpenReviewRequests(client, "owner", "repo");
       expect(result).toEqual([]);
       expect(listReviews).not.toHaveBeenCalled();
+    });
+
+    it("falls back to review_required when listReviews throws for a PR", async () => {
+      const listReviews = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("rate limit"))
+        .mockResolvedValueOnce({
+          data: [{ user: { login: "x" }, state: "APPROVED" }],
+        });
+      const client = {
+        paginate: vi.fn(async () => [
+          makePr({
+            number: 1,
+            requested_reviewers: [{ login: "alice" }],
+          }),
+          makePr({
+            number: 2,
+            requested_reviewers: [{ login: "alice" }],
+          }),
+        ]),
+        rest: { pulls: { list: vi.fn(), listReviews } },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+
+      const result = await fetchOpenReviewRequests(client, "owner", "repo");
+      const alice = result.find((r) => r.githubName === "alice");
+      assert(alice);
+      // どちらの PR の listReviews が先に呼ばれるかは並列実行で順不同なため、
+      // 失敗側が review_required にフォールバックしていることだけを確認する
+      const states = alice.prs.map((p) => p.approvalState).sort();
+      expect(states).toEqual(["review_required", "review_required"]);
+    });
+  });
+
+  describe("buildReviewReminderMessage section splitting", () => {
+    it("splits a reviewer's section across multiple blocks when the text limit is exceeded", () => {
+      const longTitle = "x".repeat(200);
+      const prs = Array.from({ length: 60 }, (_, i) =>
+        makeEntryPr({
+          number: i + 1,
+          title: longTitle,
+          url: `https://example.com/pr/${i + 1}`,
+        }),
+      );
+      const entries: ReminderEntry[] = [
+        {
+          githubName: "alice",
+          slackId: "U_ALICE",
+          isTeam: false,
+          prs,
+        },
+      ];
+
+      const result = buildReviewReminderMessage(
+        entries,
+        "owner/repo",
+        FIXED_NOW,
+      );
+      assert(result);
+      // header section + divider + 複数の reviewer section (分割される)
+      const reviewerBlocks = result.blocks.slice(2) as Array<{
+        type: string;
+        text: { type: string; text: string };
+      }>;
+      expect(reviewerBlocks.length).toBeGreaterThan(1);
+      for (const b of reviewerBlocks) {
+        expect(b.text.text.length).toBeLessThanOrEqual(3000);
+      }
+      // 2 つ目以降の section は "(cont.)" マーカーで始まる
+      expect(reviewerBlocks[1].text.text.startsWith("<@U_ALICE> (cont.)")).toBe(
+        true,
+      );
     });
   });
 });

--- a/__tests__/modules/reviewReminder.test.ts
+++ b/__tests__/modules/reviewReminder.test.ts
@@ -1,4 +1,4 @@
-import { vi } from "vitest";
+import { assert, vi } from "vitest";
 
 import {
   aggregateApprovalState,
@@ -166,8 +166,8 @@ describe("reviewReminder", () => {
         "owner/repo",
         FIXED_NOW,
       );
-      expect(result).not.toBeNull();
-      const { text, blocks } = result!;
+      assert(result, "expected a non-null payload");
+      const { text, blocks } = result;
 
       expect(text).toContain("owner/repo");
       expect(text).toContain("<@U_ALICE>");
@@ -210,8 +210,9 @@ describe("reviewReminder", () => {
         "owner/repo",
         FIXED_NOW,
       );
-      expect(result!.text).toContain("<!subteam^S_TEAM>");
-      expect(result!.text).toContain("<https://example.com/pr/2|#2 Feature X>");
+      assert(result);
+      expect(result.text).toContain("<!subteam^S_TEAM>");
+      expect(result.text).toContain("<https://example.com/pr/2|#2 Feature X>");
     });
 
     it("renders unmapped user with backticked github name", () => {
@@ -228,8 +229,9 @@ describe("reviewReminder", () => {
         "owner/repo",
         FIXED_NOW,
       );
-      expect(result!.text).toContain("`bob`");
-      expect(result!.text).not.toContain("<@");
+      assert(result);
+      expect(result.text).toContain("`bob`");
+      expect(result.text).not.toContain("<@");
     });
 
     it("renders distinct approval state emoji and label", () => {
@@ -258,15 +260,15 @@ describe("reviewReminder", () => {
         },
       ];
 
-      const { text } = buildReviewReminderMessage(
+      const result = buildReviewReminderMessage(
         entries,
         "owner/repo",
         FIXED_NOW,
-      )!;
-
-      expect(text).toContain(":white_check_mark: approved");
-      expect(text).toContain(":warning: changes requested");
-      expect(text).toContain(":hourglass_flowing_sand: review required");
+      );
+      assert(result);
+      expect(result.text).toContain(":white_check_mark: approved");
+      expect(result.text).toContain(":warning: changes requested");
+      expect(result.text).toContain(":hourglass_flowing_sand: review required");
     });
 
     it("truncates long label lists with +N more", () => {
@@ -282,12 +284,13 @@ describe("reviewReminder", () => {
         },
       ];
 
-      const { text } = buildReviewReminderMessage(
+      const result = buildReviewReminderMessage(
         entries,
         "owner/repo",
         FIXED_NOW,
-      )!;
-      expect(text).toContain("+2 more");
+      );
+      assert(result);
+      expect(result.text).toContain("+2 more");
     });
 
     it("emits one section block per reviewer entry plus header and divider", () => {
@@ -305,17 +308,18 @@ describe("reviewReminder", () => {
         },
       ];
 
-      const { blocks } = buildReviewReminderMessage(
+      const result = buildReviewReminderMessage(
         entries,
         "owner/repo",
         FIXED_NOW,
-      )!;
-      expect(blocks).toHaveLength(4);
-      expect(blocks[2]).toMatchObject({
+      );
+      assert(result);
+      expect(result.blocks).toHaveLength(4);
+      expect(result.blocks[2]).toMatchObject({
         type: "section",
         text: { type: "mrkdwn" },
       });
-      expect(blocks[3]).toMatchObject({
+      expect(result.blocks[3]).toMatchObject({
         type: "section",
         text: { type: "mrkdwn" },
       });
@@ -393,14 +397,16 @@ describe("reviewReminder", () => {
       expect(byName.alice.isTeam).toBe(false);
       expect(byName.alice.prs).toHaveLength(2);
 
-      const pr1 = byName.alice.prs.find((p) => p.number === 1)!;
+      const pr1 = byName.alice.prs.find((p) => p.number === 1);
+      assert(pr1);
       expect(pr1.title).toBe("PR1");
       expect(pr1.url).toBe("https://example.com/pr/1");
       expect(pr1.createdAt).toBe("2026-05-14T12:00:00Z");
       expect(pr1.approvalState).toBe("approved");
       expect(pr1.labels).toEqual(["bug", "ui"]);
 
-      const pr2 = byName.alice.prs.find((p) => p.number === 2)!;
+      const pr2 = byName.alice.prs.find((p) => p.number === 2);
+      assert(pr2);
       expect(pr2.approvalState).toBe("changes_requested");
       expect(pr2.labels).toEqual([]);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -244,14 +244,18 @@ export const execReviewReminder = async (
     slackId: mapping[r.githubName],
   }));
 
-  const message = buildReviewReminderMessage(entries, `${owner}/${repo}`);
-  if (!message) {
+  const payload = buildReviewReminderMessage(entries, `${owner}/${repo}`);
+  if (!payload) {
     debug("finish execReviewReminder because no pending reviews");
     return;
   }
 
   const { slackWebhookUrl, iconUrl, botName } = allInputs;
-  await slackClient.postToSlack(slackWebhookUrl, message, { iconUrl, botName });
+  await slackClient.postToSlack(slackWebhookUrl, payload.text, {
+    iconUrl,
+    botName,
+    blocks: payload.blocks,
+  });
 };
 
 const buildCurrentJobUrl = (runId: string) => {

--- a/src/modules/reviewReminder.ts
+++ b/src/modules/reviewReminder.ts
@@ -134,7 +134,7 @@ export const fetchOpenReviewRequests = async (
     return reviewerCount > 0 || teamCount > 0;
   });
 
-  const approvalStates = await mapWithConcurrency(
+  const enriched = await mapWithConcurrency(
     pendingPrs,
     APPROVAL_API_CONCURRENCY,
     async (pr) => {
@@ -143,7 +143,10 @@ export const fetchOpenReviewRequests = async (
         repo,
         pull_number: pr.number,
       });
-      return aggregateApprovalState(data as ReviewLike[]);
+      return {
+        pr,
+        approvalState: aggregateApprovalState(data as ReviewLike[]),
+      };
     },
   );
 
@@ -161,23 +164,21 @@ export const fetchOpenReviewRequests = async (
     map.set(key, list);
   };
 
-  pendingPrs.forEach((pr, idx) => {
+  for (const { pr, approvalState } of enriched) {
     const item: ReminderPr = {
       number: pr.number,
       title: pr.title,
       url: pr.html_url,
       createdAt: pr.created_at,
-      approvalState: approvalStates[idx],
-      labels: (pr.labels ?? [])
-        .map((l: unknown) => {
-          if (typeof l === "string") return l;
-          if (l && typeof l === "object" && "name" in l) {
-            const name = (l as { name?: unknown }).name;
-            return typeof name === "string" ? name : "";
-          }
-          return "";
-        })
-        .filter((name: string) => name.length > 0),
+      approvalState,
+      labels: (pr.labels ?? []).flatMap((l: unknown) => {
+        if (typeof l === "string") return [l];
+        if (l && typeof l === "object" && "name" in l) {
+          const name = (l as { name?: unknown }).name;
+          if (typeof name === "string" && name.length > 0) return [name];
+        }
+        return [];
+      }),
     };
 
     for (const reviewer of pr.requested_reviewers ?? []) {
@@ -187,7 +188,7 @@ export const fetchOpenReviewRequests = async (
     for (const team of pr.requested_teams ?? []) {
       addPr(teamEntries, team?.name, item);
     }
-  });
+  }
 
   const toEntries = (
     map: Map<string, ReminderPr[]>,

--- a/src/modules/reviewReminder.ts
+++ b/src/modules/reviewReminder.ts
@@ -39,6 +39,7 @@ const APPROVAL_API_CONCURRENCY = 5;
 const LABEL_DISPLAY_LIMIT = 5;
 // Slack section block text.text の上限は 3000 文字。安全余白を取って分割閾値を決める。
 const SECTION_TEXT_LIMIT = 2800;
+const CONTINUATION_SUFFIX = " (cont.)";
 
 const mapWithConcurrency = async <T, R>(
   items: T[],
@@ -56,7 +57,6 @@ const mapWithConcurrency = async <T, R>(
 
 export const aggregateApprovalState = (
   reviews: ReviewLike[],
-  hasPendingRequest: boolean,
 ): ApprovalState => {
   const latestByReviewer = new Map<string, string>();
   for (const review of reviews) {
@@ -66,19 +66,16 @@ export const aggregateApprovalState = (
     if (state === "APPROVED" || state === "CHANGES_REQUESTED") {
       latestByReviewer.set(login, state);
     } else if (state === "DISMISSED") {
-      // DISMISSED は過去の APPROVED / CHANGES_REQUESTED を無効化する意思表示
+      // DISMISSED は過去の APPROVED / CHANGES_REQUESTED を無効化する
       latestByReviewer.delete(login);
     }
-    // COMMENTED / PENDING は意思表示として扱わない
   }
 
   if (latestByReviewer.size === 0) return "review_required";
   for (const state of latestByReviewer.values()) {
     if (state === "CHANGES_REQUESTED") return "changes_requested";
   }
-  // 残りは全員 APPROVED。ただし pending reviewer が残っていれば、
-  // リマインダー対象者視点では「review_required」を優先する。
-  return hasPendingRequest ? "review_required" : "approved";
+  return "approved";
 };
 
 export const formatRelativeAge = (createdAt: Date, now: Date): string => {
@@ -130,14 +127,16 @@ const buildPrLine = (pr: ReminderPr, now: Date): string => {
 const splitSectionByLimit = (header: string, prLines: string[]): string[] => {
   const sections: string[] = [];
   let current = header;
+  let hasContent = false;
   for (const line of prLines) {
     const candidate = `${current}\n${line}`;
-    if (candidate.length > SECTION_TEXT_LIMIT && current !== header) {
+    if (hasContent && candidate.length > SECTION_TEXT_LIMIT) {
       sections.push(current);
-      current = `${header} (cont.)\n${line}`;
+      current = `${header}${CONTINUATION_SUFFIX}\n${line}`;
     } else {
       current = candidate;
     }
+    hasContent = true;
   }
   sections.push(current);
   return sections;
@@ -172,13 +171,14 @@ export const fetchOpenReviewRequests = async (
           repo,
           pull_number: pr.number,
         });
-        return {
-          pr,
-          approvalState: aggregateApprovalState(data as ReviewLike[], true),
-        };
+        const base = aggregateApprovalState(data as ReviewLike[]);
+        // pendingPrs フィルタを通過した PR には必ず未レビューの reviewer が残るため、
+        // 「全員 APPROVED」だけで approved を出すと、リマインドを受ける本人視点では
+        // 自分の review がまだ残っているのに approved と表示されてしまう。
+        const approvalState: ApprovalState =
+          base === "approved" ? "review_required" : base;
+        return { pr, approvalState };
       } catch (e) {
-        // 1 件の review 取得失敗でリマインダ全体を落とさず、
-        // フォールバックとして review_required 表示にする
         const reason = e instanceof Error ? e.message : String(e);
         warning(
           `Failed to fetch reviews for PR #${pr.number}: ${reason}. Falling back to review_required.`,

--- a/src/modules/reviewReminder.ts
+++ b/src/modules/reviewReminder.ts
@@ -32,7 +32,6 @@ export type ReminderSlackPayload = {
 type ReviewLike = {
   user?: { login?: string | null } | null;
   state?: string | null;
-  submitted_at?: string | null;
 };
 
 const APPROVAL_API_CONCURRENCY = 5;

--- a/src/modules/reviewReminder.ts
+++ b/src/modules/reviewReminder.ts
@@ -1,8 +1,17 @@
 import type { getOctokit } from "@actions/github";
 
+export type ApprovalState =
+  | "approved"
+  | "changes_requested"
+  | "review_required";
+
 export type ReminderPr = {
+  number: number;
   title: string;
   url: string;
+  createdAt: string;
+  approvalState: ApprovalState;
+  labels: string[];
 };
 
 export type RawReminderEntry = {
@@ -13,6 +22,97 @@ export type RawReminderEntry = {
 
 export type ReminderEntry = RawReminderEntry & {
   slackId?: string;
+};
+
+export type ReminderSlackPayload = {
+  text: string;
+  blocks: unknown[];
+};
+
+type ReviewLike = {
+  user?: { login?: string | null } | null;
+  state?: string | null;
+  submitted_at?: string | null;
+};
+
+const APPROVAL_API_CONCURRENCY = 5;
+const LABEL_DISPLAY_LIMIT = 5;
+
+const mapWithConcurrency = async <T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> => {
+  const results: R[] = [];
+  for (let i = 0; i < items.length; i += concurrency) {
+    const chunk = items.slice(i, i + concurrency);
+    const chunkResults = await Promise.all(chunk.map(fn));
+    results.push(...chunkResults);
+  }
+  return results;
+};
+
+export const aggregateApprovalState = (
+  reviews: ReviewLike[],
+): ApprovalState => {
+  const latestByReviewer = new Map<string, string>();
+  for (const review of reviews) {
+    const login = review.user?.login;
+    const state = review.state;
+    if (!login || !state) continue;
+    // COMMENTED / DISMISSED / PENDING はレビュアーの意思表示として扱わない
+    if (state !== "APPROVED" && state !== "CHANGES_REQUESTED") continue;
+    latestByReviewer.set(login, state);
+  }
+
+  if (latestByReviewer.size === 0) return "review_required";
+  for (const state of latestByReviewer.values()) {
+    if (state === "CHANGES_REQUESTED") return "changes_requested";
+  }
+  return "approved";
+};
+
+export const formatRelativeAge = (createdAt: Date, now: Date): string => {
+  const diffMs = now.getTime() - createdAt.getTime();
+  if (diffMs < 0) return "just now";
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 1) return "just now";
+  const diffHour = Math.floor(diffMin / 60);
+  if (diffHour < 1) return `${diffMin}m`;
+  const diffDay = Math.floor(diffHour / 24);
+  if (diffDay < 1) return `${diffHour}h`;
+  return `${diffDay}d`;
+};
+
+export const formatLabels = (labels: string[]): string => {
+  if (labels.length === 0) return "";
+  const shown = labels.slice(0, LABEL_DISPLAY_LIMIT).map((l) => `\`${l}\``);
+  const overflow = labels.length - LABEL_DISPLAY_LIMIT;
+  return overflow > 0
+    ? `${shown.join(", ")}, +${overflow} more`
+    : shown.join(", ");
+};
+
+const APPROVAL_DISPLAY: Record<
+  ApprovalState,
+  { emoji: string; label: string }
+> = {
+  approved: { emoji: ":white_check_mark:", label: "approved" },
+  changes_requested: { emoji: ":warning:", label: "changes requested" },
+  review_required: {
+    emoji: ":hourglass_flowing_sand:",
+    label: "review required",
+  },
+};
+
+const buildPrLine = (pr: ReminderPr, now: Date): string => {
+  const age = formatRelativeAge(new Date(pr.createdAt), now);
+  const approval = APPROVAL_DISPLAY[pr.approvalState];
+  const labelText = formatLabels(pr.labels);
+  const metaParts = [age, `${approval.emoji} ${approval.label}`];
+  if (labelText) metaParts.push(labelText);
+  const meta = `_${metaParts.join(" • ")}_`;
+  return `• <${pr.url}|#${pr.number} ${pr.title}>\n${meta}`;
 };
 
 export const fetchOpenReviewRequests = async (
@@ -26,6 +126,26 @@ export const fetchOpenReviewRequests = async (
     state: "open",
     per_page: 100,
   });
+
+  const pendingPrs = prs.filter((pr) => {
+    if (pr.draft) return false;
+    const reviewerCount = (pr.requested_reviewers ?? []).length;
+    const teamCount = (pr.requested_teams ?? []).length;
+    return reviewerCount > 0 || teamCount > 0;
+  });
+
+  const approvalStates = await mapWithConcurrency(
+    pendingPrs,
+    APPROVAL_API_CONCURRENCY,
+    async (pr) => {
+      const { data } = await octokit.rest.pulls.listReviews({
+        owner,
+        repo,
+        pull_number: pr.number,
+      });
+      return aggregateApprovalState(data as ReviewLike[]);
+    },
+  );
 
   const userEntries = new Map<string, ReminderPr[]>();
   const teamEntries = new Map<string, ReminderPr[]>();
@@ -41,10 +161,24 @@ export const fetchOpenReviewRequests = async (
     map.set(key, list);
   };
 
-  for (const pr of prs) {
-    if (pr.draft) continue;
-
-    const item: ReminderPr = { title: pr.title, url: pr.html_url };
+  pendingPrs.forEach((pr, idx) => {
+    const item: ReminderPr = {
+      number: pr.number,
+      title: pr.title,
+      url: pr.html_url,
+      createdAt: pr.created_at,
+      approvalState: approvalStates[idx],
+      labels: (pr.labels ?? [])
+        .map((l: unknown) => {
+          if (typeof l === "string") return l;
+          if (l && typeof l === "object" && "name" in l) {
+            const name = (l as { name?: unknown }).name;
+            return typeof name === "string" ? name : "";
+          }
+          return "";
+        })
+        .filter((name: string) => name.length > 0),
+    };
 
     for (const reviewer of pr.requested_reviewers ?? []) {
       addPr(userEntries, reviewer?.login, item);
@@ -53,7 +187,7 @@ export const fetchOpenReviewRequests = async (
     for (const team of pr.requested_teams ?? []) {
       addPr(teamEntries, team?.name, item);
     }
-  }
+  });
 
   const toEntries = (
     map: Map<string, ReminderPr[]>,
@@ -66,29 +200,43 @@ export const fetchOpenReviewRequests = async (
   return [...toEntries(userEntries, false), ...toEntries(teamEntries, true)];
 };
 
+const buildEntryHeader = (entry: ReminderEntry): string => {
+  if (entry.slackId) {
+    return entry.isTeam ? `<!subteam^${entry.slackId}>` : `<@${entry.slackId}>`;
+  }
+  return `\`${entry.githubName}\``;
+};
+
 export const buildReviewReminderMessage = (
   entries: ReminderEntry[],
   repoFullName: string,
-): string | null => {
+  now: Date = new Date(),
+): ReminderSlackPayload | null => {
   if (entries.length === 0) return null;
 
-  const sections = entries.map((entry) => {
-    const header = (() => {
-      if (entry.slackId) {
-        return entry.isTeam
-          ? `<!subteam^${entry.slackId}>`
-          : `<@${entry.slackId}>`;
-      }
-      return `\`${entry.githubName}\``;
-    })();
+  const headerText = `:eyes: Pending review reminders for \`${repoFullName}\`:`;
 
-    const lines = entry.prs.map((pr) => `  • <${pr.url}|${pr.title}>`);
-    return [header, ...lines].join("\n");
+  const entrySections = entries.map((entry) => {
+    const header = buildEntryHeader(entry);
+    const prLines = entry.prs.map((pr) => buildPrLine(pr, now));
+    return [header, ...prLines].join("\n");
   });
 
-  return [
-    `:eyes: Pending review reminders for \`${repoFullName}\`:`,
-    "",
-    sections.join("\n\n"),
-  ].join("\n");
+  const text = [headerText, "", entrySections.join("\n\n")].join("\n");
+
+  const blocks: unknown[] = [
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: headerText },
+    },
+    { type: "divider" },
+  ];
+  for (const section of entrySections) {
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: section },
+    });
+  }
+
+  return { text, blocks };
 };

--- a/src/modules/reviewReminder.ts
+++ b/src/modules/reviewReminder.ts
@@ -1,3 +1,4 @@
+import { warning } from "@actions/core";
 import type { getOctokit } from "@actions/github";
 
 export type ApprovalState =
@@ -36,6 +37,8 @@ type ReviewLike = {
 
 const APPROVAL_API_CONCURRENCY = 5;
 const LABEL_DISPLAY_LIMIT = 5;
+// Slack section block text.text の上限は 3000 文字。安全余白を取って分割閾値を決める。
+const SECTION_TEXT_LIMIT = 2800;
 
 const mapWithConcurrency = async <T, R>(
   items: T[],
@@ -53,22 +56,29 @@ const mapWithConcurrency = async <T, R>(
 
 export const aggregateApprovalState = (
   reviews: ReviewLike[],
+  hasPendingRequest: boolean,
 ): ApprovalState => {
   const latestByReviewer = new Map<string, string>();
   for (const review of reviews) {
     const login = review.user?.login;
     const state = review.state;
     if (!login || !state) continue;
-    // COMMENTED / DISMISSED / PENDING はレビュアーの意思表示として扱わない
-    if (state !== "APPROVED" && state !== "CHANGES_REQUESTED") continue;
-    latestByReviewer.set(login, state);
+    if (state === "APPROVED" || state === "CHANGES_REQUESTED") {
+      latestByReviewer.set(login, state);
+    } else if (state === "DISMISSED") {
+      // DISMISSED は過去の APPROVED / CHANGES_REQUESTED を無効化する意思表示
+      latestByReviewer.delete(login);
+    }
+    // COMMENTED / PENDING は意思表示として扱わない
   }
 
   if (latestByReviewer.size === 0) return "review_required";
   for (const state of latestByReviewer.values()) {
     if (state === "CHANGES_REQUESTED") return "changes_requested";
   }
-  return "approved";
+  // 残りは全員 APPROVED。ただし pending reviewer が残っていれば、
+  // リマインダー対象者視点では「review_required」を優先する。
+  return hasPendingRequest ? "review_required" : "approved";
 };
 
 export const formatRelativeAge = (createdAt: Date, now: Date): string => {
@@ -85,7 +95,10 @@ export const formatRelativeAge = (createdAt: Date, now: Date): string => {
 
 export const formatLabels = (labels: string[]): string => {
   if (labels.length === 0) return "";
-  const shown = labels.slice(0, LABEL_DISPLAY_LIMIT).map((l) => `\`${l}\``);
+  // ラベル名内のバックティックは Slack mrkdwn の inline code を破壊するため除去
+  const shown = labels
+    .slice(0, LABEL_DISPLAY_LIMIT)
+    .map((l) => `\`${l.replace(/`/g, "")}\``);
   const overflow = labels.length - LABEL_DISPLAY_LIMIT;
   return overflow > 0
     ? `${shown.join(", ")}, +${overflow} more`
@@ -114,6 +127,22 @@ const buildPrLine = (pr: ReminderPr, now: Date): string => {
   return `• <${pr.url}|#${pr.number} ${pr.title}>\n${meta}`;
 };
 
+const splitSectionByLimit = (header: string, prLines: string[]): string[] => {
+  const sections: string[] = [];
+  let current = header;
+  for (const line of prLines) {
+    const candidate = `${current}\n${line}`;
+    if (candidate.length > SECTION_TEXT_LIMIT && current !== header) {
+      sections.push(current);
+      current = `${header} (cont.)\n${line}`;
+    } else {
+      current = candidate;
+    }
+  }
+  sections.push(current);
+  return sections;
+};
+
 export const fetchOpenReviewRequests = async (
   octokit: ReturnType<typeof getOctokit>,
   owner: string,
@@ -137,15 +166,25 @@ export const fetchOpenReviewRequests = async (
     pendingPrs,
     APPROVAL_API_CONCURRENCY,
     async (pr) => {
-      const { data } = await octokit.rest.pulls.listReviews({
-        owner,
-        repo,
-        pull_number: pr.number,
-      });
-      return {
-        pr,
-        approvalState: aggregateApprovalState(data as ReviewLike[]),
-      };
+      try {
+        const { data } = await octokit.rest.pulls.listReviews({
+          owner,
+          repo,
+          pull_number: pr.number,
+        });
+        return {
+          pr,
+          approvalState: aggregateApprovalState(data as ReviewLike[], true),
+        };
+      } catch (e) {
+        // 1 件の review 取得失敗でリマインダ全体を落とさず、
+        // フォールバックとして review_required 表示にする
+        const reason = e instanceof Error ? e.message : String(e);
+        warning(
+          `Failed to fetch reviews for PR #${pr.number}: ${reason}. Falling back to review_required.`,
+        );
+        return { pr, approvalState: "review_required" as const };
+      }
     },
   );
 
@@ -216,13 +255,17 @@ export const buildReviewReminderMessage = (
 
   const headerText = `:eyes: Pending review reminders for \`${repoFullName}\`:`;
 
-  const entrySections = entries.map((entry) => {
+  const entryBlockTexts: string[] = [];
+  const entryTextSections: string[] = [];
+
+  for (const entry of entries) {
     const header = buildEntryHeader(entry);
     const prLines = entry.prs.map((pr) => buildPrLine(pr, now));
-    return [header, ...prLines].join("\n");
-  });
+    entryTextSections.push([header, ...prLines].join("\n"));
+    entryBlockTexts.push(...splitSectionByLimit(header, prLines));
+  }
 
-  const text = [headerText, "", entrySections.join("\n\n")].join("\n");
+  const text = [headerText, "", entryTextSections.join("\n\n")].join("\n");
 
   const blocks: unknown[] = [
     {
@@ -231,7 +274,7 @@ export const buildReviewReminderMessage = (
     },
     { type: "divider" },
   ];
-  for (const section of entrySections) {
+  for (const section of entryBlockTexts) {
     blocks.push({
       type: "section",
       text: { type: "mrkdwn", text: section },

--- a/src/modules/slack.ts
+++ b/src/modules/slack.ts
@@ -67,6 +67,7 @@ export const buildSlackErrorMessage = (
 export type SlackOption = {
   iconUrl?: string;
   botName?: string;
+  blocks?: unknown[];
 };
 
 type SlackPostParam = {
@@ -75,6 +76,7 @@ type SlackPostParam = {
   username: string;
   icon_url?: string;
   icon_emoji?: string;
+  blocks?: unknown[];
 };
 
 const defaultBotName = "Github Mention To Slack";
@@ -105,6 +107,10 @@ export const SlackRepositoryImpl = {
       slackPostParam.icon_url = u;
     } else {
       slackPostParam.icon_emoji = defaultIconEmoji;
+    }
+
+    if (options?.blocks && options.blocks.length > 0) {
+      slackPostParam.blocks = options.blocks;
     }
 
     const response = await fetch(webhookUrl, {


### PR DESCRIPTION
## Summary

Closes #351.

純正 GitHub Scheduled Reminders の代替として使えるよう、`scheduled-reminder` モードの Slack 通知に PR の詳細情報を追加した。

- 各 PR エントリに **PR 番号 / 経過時間 / approval state / ラベル** を表示
- 出力を **Slack Block Kit** に切り替え (text フォールバックも併送)
- approval state は `pulls.listReviews` でレビュアーごとに最新 state を集約 (`CHANGES_REQUESTED` 優勢、全員 `APPROVED` で `approved`、それ以外は `review_required`)
- 追加 API call は pending reviewer/team を持つ PR のみに絞り、**5 並列 chunk** で実行してレート制限に配慮

`realtime-alert` 系の呼び出しは `postToSlack` への新オプション `blocks` を渡さないため挙動不変。

## 出力例 (text フォールバック)

```
:eyes: Pending review reminders for `owner/repo`:

<@U_ALICE>
• <https://github.com/owner/repo/pull/123|#123 Fix login bug>
_3d • :warning: changes requested • `bug`, `priority-high`_
• <https://github.com/owner/repo/pull/130|#130 Refactor auth>
_5h • :hourglass_flowing_sand: review required_
```

## Test plan

- [x] `npm test` (100 passed)
- [x] `npm run lint` (tsc + biome、warning なし)
- [x] `npm run build` (ncc)
- [ ] 本番 Webhook での手動結合確認 (任意; Block Kit Builder への貼り付けでレイアウトを目視確認可能)