### PR TITLE
Document required permissions for scheduled-reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ _5h • :hourglass_flowing_sand: review required_
 - If there are no pending review requests, nothing is posted.
 - Approval state is fetched via the `pulls.listReviews` API for each PR with pending reviewers. Calls are made in chunks of 5 to stay friendly to API rate limits.
 
+`scheduled-reminder` calls the GitHub REST API, so the job needs `pull-requests: read` (for `pulls.list` / `pulls.listReviews`) and `contents: read` (to fetch the configuration YAML via `repos.getContent`). If your repository or organization defaults the workflow `GITHUB_TOKEN` to read-only or restricted scopes, omitting these will surface as `HttpError: Resource not accessible by integration`. Set them at the job level as shown below.
+
 .github/workflows/review-reminder.yml
 
 ```yml
@@ -112,6 +114,9 @@ on:
 jobs:
   review-reminder:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Run
         uses: abeyuya/actions-mention-to-slack@v2


### PR DESCRIPTION
## Summary

- `scheduled-reminder` モード実行時に `HttpError: Resource not accessible by integration` が発生する原因 (利用者ワークフローでの GitHub Actions 権限不足) を README で解消する。
- `README.md` の scheduled-reminder サンプルワークフローに以下を追加:
  - 説明文 1 段落: なぜ `pull-requests: read` と `contents: read` が必要か (`pulls.list` / `pulls.listReviews` / `repos.getContent` 用) と、欠落時に出るエラー文字列。
  - サンプル YAML の `jobs.review-reminder` 配下に `permissions: contents: read / pull-requests: read` を追記。
- コード側 (`src/modules/reviewReminder.ts` / `src/modules/mappingConfig.ts` / `action.yml`) の挙動は変更なし。

## Test plan

- [ ] README のレンダリングで、新しい段落とサンプル YAML がそれぞれ正しく表示されることを確認
- [ ] サンプル YAML をそのまま `.github/workflows/review-reminder.yml` にコピーした際に GitHub Actions として valid な YAML であること (インデント / `permissions:` の階層) を目視確認
- [ ] (任意) 実環境で scheduled-reminder ワークフローを再実行し、`HttpError: Resource not accessible by integration` が再発しないこと

https://claude.ai/code/session_017EAfi23tdSwci6QvzdtoQH

---
_Generated by [Claude Code](https://claude.ai/code/session_017EAfi23tdSwci6QvzdtoQH)_