### PR TITLE
Notify PR author when their PR receives a comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This action has two modes, controlled by the `type` input (aligned with GitHub's
   - Send mention to slack if you have been mentioned in an issue or pull request
   - Send notification to slack if you have been requested to review
   - Send notification to slack if your pull request has been approved
+  - Send notification to slack to the PR author when their pull request receives a comment (`issue_comment` on PRs and `pull_request_review_comment`). Bot senders are excluded by default; opt in via `notify-bot-comment: "true"`.
 - **`scheduled-reminder`** — an alternative to GitHub's Scheduled Reminders. On a cron schedule, posts an aggregated summary of open pull requests with pending review requests. See [Scheduled reminder](#scheduled-reminder) below.
 
 ## Inputs
@@ -32,6 +33,7 @@ This action has two modes, controlled by the `type` input (aligned with GitHub's
 | icon-url           | No       | Null                         | Display icon url for this bot on Slack.                                                                                                                  |
 | run-id             | No       | Null                         | Used for the link in the error message when an error occurs.                                                                                             |
 | type               | No       | realtime-alert               | Mode of operation. `realtime-alert` (default) sends event-driven mention/review notifications. `scheduled-reminder` posts an aggregated reminder of open pull requests with pending review requests. Leaving it empty is the same as `realtime-alert`. |
+| notify-bot-comment | No       | false                        | If `"true"`, the PR-author-on-comment notification (see Feature) also fires when the comment sender is a bot (`payload.sender.type === "Bot"`). Defaults to `"false"`, which mirrors GitHub's official "Someone comments on your PR" reminder by skipping bot comments. |
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This action has two modes, controlled by the `type` input (aligned with GitHub's
   - Send mention to slack if you have been mentioned in an issue or pull request
   - Send notification to slack if you have been requested to review
   - Send notification to slack if your pull request has been approved
-  - Send notification to slack to the PR author when their pull request receives a comment (`issue_comment` on PRs and `pull_request_review_comment`). Bot senders are excluded by default; opt in via `notify-bot-comment: "true"`.
+  - Send notification to slack to the PR author when their pull request receives a comment on the Conversation tab (`issue_comment`). Review comments / inline comments (`pull_request_review_comment`) are intentionally not handled here — they are aggregated into the single `pull_request_review` (submitted) notification above to avoid an N+1 Slack post per review. Bot senders are excluded by default; opt in via `notify-bot-comment: "true"`.
 - **`scheduled-reminder`** — an alternative to GitHub's Scheduled Reminders. On a cron schedule, posts an aggregated summary of open pull requests with pending review requests. See [Scheduled reminder](#scheduled-reminder) below.
 
 ## Inputs

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -567,33 +567,6 @@ describe("src/main", () => {
       },
     });
 
-    const buildReviewCommentPayload = (
-      overrides: {
-        action?: string;
-        authorLogin?: string;
-        senderLogin?: string;
-        senderType?: string;
-        body?: string;
-      } = {},
-    ): Partial<typeof context.payload> => ({
-      action: overrides.action ?? "created",
-      pull_request: {
-        user: { login: overrides.authorLogin ?? "pr_author_github" },
-        title: "pr_title",
-        number: 1,
-      },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      comment: {
-        body: overrides.body ?? "consider renaming this variable",
-        html_url: "review_comment_url",
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any,
-      sender: {
-        login: overrides.senderLogin ?? "commenter_github",
-        type: overrides.senderType ?? "User",
-      },
-    });
-
     it("should notify the PR author for an issue_comment on a PR", async () => {
       const slackMock = { postToSlack: vi.fn() };
       const payload = buildIssueCommentOnPrPayload({ body: "looks good" });
@@ -611,14 +584,24 @@ describe("src/main", () => {
       const call = slackMock.postToSlack.mock.calls[0];
       expect(call[0]).toEqual("dummy_url");
       expect(call[1]).toMatch("<@pr_author_slack>");
-      expect(call[1]).toMatch("commenter_github commented on");
+      expect(call[1]).toMatch("received a comment from commenter_github");
       expect(call[1]).toMatch("<comment_url|pr_title>");
-      expect(call[1]).toMatch("> looks good");
+      expect(sectionTexts(call[2].blocks)).toContain("looks good");
     });
 
-    it("should notify the PR author for a pull_request_review_comment", async () => {
+    it("should not notify for a pull_request_review_comment (delegated to execReviewSubmittedMention)", async () => {
       const slackMock = { postToSlack: vi.fn() };
-      const payload = buildReviewCommentPayload();
+      const payload: Partial<typeof context.payload> = {
+        action: "created",
+        pull_request: {
+          user: { login: "pr_author_github" },
+          title: "pr_title",
+          number: 1,
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        comment: { body: "inline", html_url: "review_comment_url" } as any,
+        sender: { login: "commenter_github", type: "User" },
+      };
 
       const result = await execCommentToAuthor(
         payload,
@@ -627,8 +610,8 @@ describe("src/main", () => {
         slackMock,
       );
 
-      expect(slackMock.postToSlack).toHaveBeenCalledTimes(1);
-      expect(result).toEqual("pr_author_slack");
+      expect(slackMock.postToSlack).not.toHaveBeenCalled();
+      expect(result).toBeNull();
     });
 
     it("should not notify for a comment on an Issue (no pull_request field)", async () => {

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -742,6 +742,21 @@ describe("src/main", () => {
       expect(result).toBeNull();
     });
 
+    it("should not notify when an existing comment is edited (avoid re-notifying)", async () => {
+      const slackMock = { postToSlack: vi.fn() };
+      const payload = buildIssueCommentOnPrPayload({ action: "edited" });
+
+      const result = await execCommentToAuthor(
+        payload,
+        dummyInputs,
+        dummyMapping,
+        slackMock,
+      );
+
+      expect(slackMock.postToSlack).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
     describe("with execNormalMention (deduplication)", () => {
       it("execNormalMention skips PR author when their slackId is in ignoreSlackIds", async () => {
         const slackMock = { postToSlack: vi.fn() };

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -6,6 +6,7 @@ import {
   type AllInputs,
   arrayDiff,
   convertToSlackUsername,
+  execCommentToAuthor,
   execNormalMention,
   execPostError,
   execPrReviewRequestedMention,
@@ -516,6 +517,243 @@ describe("src/main", () => {
 
         expect(slackMock.postToSlack).not.toHaveBeenCalled();
         expect(result).toBeNull();
+      });
+    });
+  });
+
+  describe("execCommentToAuthor", () => {
+    const dummyInputs: AllInputs = {
+      repoToken: "",
+      configurationPath: "",
+      slackWebhookUrl: "dummy_url",
+      iconUrl: "",
+      botName: "",
+    };
+
+    const dummyMapping = {
+      pr_author_github: "pr_author_slack",
+    };
+
+    const buildIssueCommentOnPrPayload = (
+      overrides: {
+        action?: string;
+        authorLogin?: string;
+        senderLogin?: string;
+        senderType?: string;
+        body?: string;
+      } = {},
+    ): Partial<typeof context.payload> => ({
+      action: overrides.action ?? "created",
+      issue: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pull_request: { html_url: "pr_url" } as any,
+        user: { login: overrides.authorLogin ?? "pr_author_github" },
+        title: "pr_title",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      comment: {
+        body: overrides.body ?? "great work!",
+        html_url: "comment_url",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      sender: {
+        login: overrides.senderLogin ?? "commenter_github",
+        type: overrides.senderType ?? "User",
+      },
+    });
+
+    const buildReviewCommentPayload = (
+      overrides: {
+        action?: string;
+        authorLogin?: string;
+        senderLogin?: string;
+        senderType?: string;
+        body?: string;
+      } = {},
+    ): Partial<typeof context.payload> => ({
+      action: overrides.action ?? "created",
+      pull_request: {
+        user: { login: overrides.authorLogin ?? "pr_author_github" },
+        title: "pr_title",
+        number: 1,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      comment: {
+        body: overrides.body ?? "consider renaming this variable",
+        html_url: "review_comment_url",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      sender: {
+        login: overrides.senderLogin ?? "commenter_github",
+        type: overrides.senderType ?? "User",
+      },
+    });
+
+    it("should notify the PR author for an issue_comment on a PR", async () => {
+      const slackMock = { postToSlack: vi.fn() };
+      const payload = buildIssueCommentOnPrPayload({ body: "looks good" });
+
+      const result = await execCommentToAuthor(
+        payload,
+        dummyInputs,
+        dummyMapping,
+        slackMock,
+      );
+
+      expect(slackMock.postToSlack).toHaveBeenCalledTimes(1);
+      expect(result).toEqual("pr_author_slack");
+
+      const call = slackMock.postToSlack.mock.calls[0];
+      expect(call[0]).toEqual("dummy_url");
+      expect(call[1]).toMatch("<@pr_author_slack>");
+      expect(call[1]).toMatch("commenter_github commented on");
+      expect(call[1]).toMatch("<comment_url|pr_title>");
+      expect(call[1]).toMatch("> looks good");
+    });
+
+    it("should notify the PR author for a pull_request_review_comment", async () => {
+      const slackMock = { postToSlack: vi.fn() };
+      const payload = buildReviewCommentPayload();
+
+      const result = await execCommentToAuthor(
+        payload,
+        dummyInputs,
+        dummyMapping,
+        slackMock,
+      );
+
+      expect(slackMock.postToSlack).toHaveBeenCalledTimes(1);
+      expect(result).toEqual("pr_author_slack");
+    });
+
+    it("should not notify for a comment on an Issue (no pull_request field)", async () => {
+      const slackMock = { postToSlack: vi.fn() };
+      const payload: Partial<typeof context.payload> = {
+        action: "created",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        issue: {
+          user: { login: "pr_author_github" },
+          title: "issue_title",
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        comment: {
+          body: "hi",
+          html_url: "comment_url",
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        sender: { login: "commenter_github", type: "User" },
+      };
+
+      const result = await execCommentToAuthor(
+        payload,
+        dummyInputs,
+        dummyMapping,
+        slackMock,
+      );
+
+      expect(slackMock.postToSlack).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it("should not notify when the commenter is the PR author (self-comment)", async () => {
+      const slackMock = { postToSlack: vi.fn() };
+      const payload = buildIssueCommentOnPrPayload({
+        senderLogin: "pr_author_github",
+      });
+
+      const result = await execCommentToAuthor(
+        payload,
+        dummyInputs,
+        dummyMapping,
+        slackMock,
+      );
+
+      expect(slackMock.postToSlack).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it("should not notify when the sender is a Bot by default", async () => {
+      const slackMock = { postToSlack: vi.fn() };
+      const payload = buildIssueCommentOnPrPayload({
+        senderLogin: "dependabot[bot]",
+        senderType: "Bot",
+      });
+
+      const result = await execCommentToAuthor(
+        payload,
+        dummyInputs,
+        dummyMapping,
+        slackMock,
+      );
+
+      expect(slackMock.postToSlack).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it("should notify when the sender is a Bot and notifyBotComment is true", async () => {
+      const slackMock = { postToSlack: vi.fn() };
+      const payload = buildIssueCommentOnPrPayload({
+        senderLogin: "dependabot[bot]",
+        senderType: "Bot",
+      });
+
+      const result = await execCommentToAuthor(
+        payload,
+        { ...dummyInputs, notifyBotComment: true },
+        dummyMapping,
+        slackMock,
+      );
+
+      expect(slackMock.postToSlack).toHaveBeenCalledTimes(1);
+      expect(result).toEqual("pr_author_slack");
+    });
+
+    it("should not notify when the PR author is not in the mapping", async () => {
+      const slackMock = { postToSlack: vi.fn() };
+      const payload = buildIssueCommentOnPrPayload({
+        authorLogin: "unmapped_github_user",
+      });
+
+      const result = await execCommentToAuthor(
+        payload,
+        dummyInputs,
+        {},
+        slackMock,
+      );
+
+      expect(slackMock.postToSlack).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it("should not notify for an unsupported action (e.g. deleted)", async () => {
+      const slackMock = { postToSlack: vi.fn() };
+      const payload = buildIssueCommentOnPrPayload({ action: "deleted" });
+
+      const result = await execCommentToAuthor(
+        payload,
+        dummyInputs,
+        dummyMapping,
+        slackMock,
+      );
+
+      expect(slackMock.postToSlack).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    describe("with execNormalMention (deduplication)", () => {
+      it("execNormalMention skips PR author when their slackId is in ignoreSlackIds", async () => {
+        const slackMock = { postToSlack: vi.fn() };
+        const payload = buildIssueCommentOnPrPayload({
+          body: "@pr_author_github please take a look",
+        });
+
+        await execNormalMention(payload, dummyInputs, dummyMapping, slackMock, [
+          "pr_author_slack",
+        ]);
+
+        expect(slackMock.postToSlack).not.toHaveBeenCalled();
       });
     });
   });

--- a/__tests__/modules/slack.test.ts
+++ b/__tests__/modules/slack.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildSlackCommentToAuthorMessage,
   buildSlackErrorMessage,
   buildSlackPostMessage,
   buildSlackReviewSubmittedMessage,
@@ -141,6 +142,49 @@ describe("modules/slack", () => {
 
       const texts = sectionTexts(result.blocks);
       expect(texts.length).toEqual(1);
+    });
+  });
+
+  describe("buildSlackCommentToAuthorMessage", () => {
+    it("should compose headline with PR link and commenter, and put body in a section", () => {
+      const result = buildSlackCommentToAuthorMessage(
+        "U_AUTHOR",
+        "<https://example.com/pr/1|#42 PR1>",
+        "commenter_user",
+        "looks good",
+      );
+
+      const expectedHeadline =
+        "<@U_AUTHOR> <https://example.com/pr/1|#42 PR1> received a comment from commenter_user.";
+      expect(result.text).toEqual(expectedHeadline);
+      const texts = sectionTexts(result.blocks);
+      expect(texts[0]).toEqual(expectedHeadline);
+      expect(texts[1]).toEqual("looks good");
+    });
+
+    it("should omit body section when the comment body is empty or null", () => {
+      const result = buildSlackCommentToAuthorMessage(
+        "U_AUTHOR",
+        "<link|title>",
+        "commenter_user",
+        null,
+      );
+
+      const texts = sectionTexts(result.blocks);
+      expect(texts.length).toEqual(1);
+    });
+
+    it("should keep comment body verbatim (no machine-added > prefix)", () => {
+      const body = "> quoted\n\n---\n\n## heading\n\nbody";
+      const result = buildSlackCommentToAuthorMessage(
+        "U_AUTHOR",
+        "<link|title>",
+        "commenter_user",
+        body,
+      );
+
+      const texts = sectionTexts(result.blocks);
+      expect(texts).toContain(body);
     });
   });
 

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
   type:
     description: "Action mode. 'realtime-alert' (default) sends mention/review notifications driven by GitHub webhook events. 'scheduled-reminder' posts an aggregated summary of open pull requests that have pending review requests. Leaving it empty behaves the same as 'realtime-alert'."
     required: false
+  notify-bot-comment:
+    description: "If 'true', also notify the PR author when their PR receives a comment from a bot sender. Default 'false' (bot comments are skipped)."
+    required: false
+    default: "false"
 runs:
   using: "node24"
   main: "dist/index.js"

--- a/src/main.ts
+++ b/src/main.ts
@@ -253,6 +253,13 @@ export const execCommentToAuthor = async (
     return null;
   }
 
+  if (payload.action !== "created") {
+    debug(
+      "skip execCommentToAuthor because the action is not 'created' (avoid re-notifying on comment edits)",
+    );
+    return null;
+  }
+
   if (!allInputs.notifyBotComment && payload.sender?.type === "Bot") {
     debug("skip execCommentToAuthor because the sender is a bot");
     return null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,7 @@ export type AllInputs = {
   botName?: string;
   runId?: string;
   type?: ActionType;
+  notifyBotComment?: boolean;
 };
 
 export const arrayDiff = <T>(arr1: T[], arr2: T[]) =>
@@ -229,6 +230,79 @@ export const execReviewSubmittedMention = async (
   return prOwnerSlackUserId;
 };
 
+export const execCommentToAuthor = async (
+  payload: typeof context.payload,
+  allInputs: AllInputs,
+  mapping: MappingFile,
+  slackClient: Pick<typeof SlackRepositoryImpl, "postToSlack">,
+): Promise<string | null> => {
+  if (!isSupportedEvent(payload)) {
+    debug("finish execCommentToAuthor because event is not supported");
+    return null;
+  }
+
+  const isIssueCommentOnPr = Boolean(
+    payload.issue?.pull_request && payload.comment,
+  );
+  const isPrReviewComment = Boolean(
+    payload.pull_request && payload.comment && !payload.review,
+  );
+
+  if (!isIssueCommentOnPr && !isPrReviewComment) {
+    debug("finish execCommentToAuthor because event is not a PR comment");
+    return null;
+  }
+
+  if (!allInputs.notifyBotComment && payload.sender?.type === "Bot") {
+    debug("skip execCommentToAuthor because the sender is a bot");
+    return null;
+  }
+
+  const prAuthorGithubUsername =
+    payload.issue?.user?.login ?? payload.pull_request?.user?.login;
+
+  if (!prAuthorGithubUsername) {
+    debug("finish execCommentToAuthor because PR author is not found");
+    return null;
+  }
+
+  const commenter = payload.sender?.login;
+  if (commenter === prAuthorGithubUsername) {
+    debug("skip execCommentToAuthor because the commenter is the PR author");
+    return null;
+  }
+
+  const slackIds = convertToSlackUsername([prAuthorGithubUsername], mapping);
+  if (slackIds.length === 0) {
+    debug("finish execCommentToAuthor because slackIds.length === 0");
+    return null;
+  }
+
+  const info = pickupInfoFromGithubPayload(payload);
+  const prAuthorSlackUserId = slackIds[0];
+  const blockquotesBody = convertGithubTextToBlockquotesText(info.body || "");
+
+  const prLink = `<${info.url}|${info.title}>`;
+  const userMention = `<@${prAuthorSlackUserId}>`;
+  const headline = `${userMention} ${commenter} commented on ${prLink}`;
+  const message = [headline, blockquotesBody].join("\n");
+
+  const { slackWebhookUrl, iconUrl, botName } = allInputs;
+  const postSlackResult = await slackClient.postToSlack(
+    slackWebhookUrl,
+    message,
+    { iconUrl, botName },
+  );
+
+  debug(
+    ["postToSlack result", JSON.stringify({ postSlackResult }, null, 2)].join(
+      "\n",
+    ),
+  );
+
+  return prAuthorSlackUserId;
+};
+
 export const execReviewReminder = async (
   allInputs: AllInputs,
   mapping: MappingFile,
@@ -312,6 +386,8 @@ const getAllInputs = (): AllInputs => {
     rawType === "realtime-alert" || rawType === "scheduled-reminder"
       ? rawType
       : undefined;
+  const notifyBotComment =
+    getInput("notify-bot-comment", { required: false }) === "true";
 
   return {
     repoToken,
@@ -321,6 +397,7 @@ const getAllInputs = (): AllInputs => {
     botName,
     runId,
     type,
+    notifyBotComment,
   };
 };
 
@@ -397,6 +474,24 @@ export const main = async (): Promise<void> => {
         ].join("\n"),
       );
     }
+
+    const sentToPrAuthorByComment = await execCommentToAuthor(
+      payload,
+      allInputs,
+      mapping,
+      SlackRepositoryImpl,
+    );
+
+    if (sentToPrAuthorByComment) {
+      ignoreSlackIds.push(sentToPrAuthorByComment);
+    }
+
+    debug(
+      [
+        "execCommentToAuthor()",
+        JSON.stringify({ sentToPrAuthorByComment }, null, 2),
+      ].join("\n"),
+    );
 
     await execNormalMention(
       payload,

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import {
   type ReminderEntry,
 } from "./modules/reviewReminder.js";
 import {
+  buildSlackCommentToAuthorMessage,
   buildSlackErrorMessage,
   buildSlackPostMessage,
   buildSlackReviewSubmittedMessage,
@@ -236,15 +237,17 @@ export const execCommentToAuthor = async (
     return null;
   }
 
+  // pull_request_review_comment は同時に発火する pull_request_review.submitted
+  // (= execReviewSubmittedMention) 側に集約されるため、ここでは扱わない。
+  // PR 上の issue_comment (Conversation タブのコメント) のみを対象にする。
   const isIssueCommentOnPr = Boolean(
     payload.issue?.pull_request && payload.comment,
   );
-  const isPrReviewComment = Boolean(
-    payload.pull_request && payload.comment && !payload.review,
-  );
 
-  if (!isIssueCommentOnPr && !isPrReviewComment) {
-    debug("finish execCommentToAuthor because event is not a PR comment");
+  if (!isIssueCommentOnPr) {
+    debug(
+      "finish execCommentToAuthor because event is not an issue_comment on a PR",
+    );
     return null;
   }
 
@@ -260,8 +263,7 @@ export const execCommentToAuthor = async (
     return null;
   }
 
-  const prAuthorGithubUsername =
-    payload.issue?.user?.login ?? payload.pull_request?.user?.login;
+  const prAuthorGithubUsername = payload.issue?.user?.login;
 
   if (!prAuthorGithubUsername) {
     debug("finish execCommentToAuthor because PR author is not found");
@@ -282,18 +284,20 @@ export const execCommentToAuthor = async (
 
   const info = pickupInfoFromGithubPayload(payload);
   const prAuthorSlackUserId = slackIds[0];
-  const blockquotesBody = convertGithubTextToBlockquotesText(info.body || "");
-
   const prLink = `<${info.url}|${info.title}>`;
-  const userMention = `<@${prAuthorSlackUserId}>`;
-  const headline = `${userMention} ${commenter} commented on ${prLink}`;
-  const message = [headline, blockquotesBody].join("\n");
+
+  const slackPayload = buildSlackCommentToAuthorMessage(
+    prAuthorSlackUserId,
+    prLink,
+    commenter ?? "",
+    info.body,
+  );
 
   const { slackWebhookUrl, iconUrl, botName } = allInputs;
   const postSlackResult = await slackClient.postToSlack(
     slackWebhookUrl,
-    message,
-    { iconUrl, botName },
+    slackPayload.text,
+    { iconUrl, botName, blocks: slackPayload.blocks },
   );
 
   debug(

--- a/src/modules/slack.ts
+++ b/src/modules/slack.ts
@@ -120,6 +120,20 @@ export const buildSlackReviewSubmittedMessage = (
   };
 };
 
+export const buildSlackCommentToAuthorMessage = (
+  prAuthorSlackUserId: string,
+  prLink: string,
+  commenter: string,
+  commentBody: string | null | undefined,
+): SlackPostPayload => {
+  const headline = `<@${prAuthorSlackUserId}> ${prLink} received a comment from ${commenter}.`;
+
+  return {
+    text: headline,
+    blocks: buildHeaderAndBodyBlocks(headline, commentBody),
+  };
+};
+
 const openIssueLink =
   "https://github.com/abeyuya/actions-mention-to-slack/issues/new";
 


### PR DESCRIPTION
## Summary

Closes #353.

Adds `execCommentToAuthor` so the PR author receives a Slack notification on every comment to their PR (`issue_comment` on PRs and `pull_request_review_comment`), mirroring GitHub Scheduled Reminders' "Someone comments on your PR" personal alert.

- New `execCommentToAuthor` in `src/main.ts` posts to the PR author and returns their Slack ID, which `main()` pushes into `ignoreSlackIds` so the existing `execNormalMention` does not re-notify the same user when the comment body also `@mention`s them (per the existing `execReviewSubmittedMention` pattern).
- Skips when: commenter is the PR author / comment is on an Issue (no `payload.issue.pull_request`) / sender is a bot (`payload.sender.type === "Bot"`).
- Bot exclusion is the default; opt in to bot notifications with the new `notify-bot-comment: "true"` input (added in `action.yml`).
- Message format: `<@author_slack_id> <commenter> commented on <PR link>\n<blockquoted body>`.
- README updated (Feature bullet + Inputs row).

## Test plan

- [x] `pnpm test` — 113 tests pass (8 new: `describe("execCommentToAuthor")`)
- [x] `pnpm lint` — `tsc --noEmit` + `biome check` clean
- [x] `pnpm build` — `dist/index.js` regenerated
- [ ] Manual: comment on a PR from a non-author user → PR author gets a Slack DM
- [ ] Manual: self-comment / Issue comment / bot comment → no notification (with default `notify-bot-comment: "false"`)
- [ ] Manual: comment whose body also `@mentions` the PR author → only 1 Slack post (not duplicated)