### PR TITLE
Fix Slack notification layout collapse by switching to Block Kit

### DIFF
--- a/__tests__/fixture/slackBlocks.ts
+++ b/__tests__/fixture/slackBlocks.ts
@@ -1,0 +1,14 @@
+export type SectionBlock = {
+  type: "section";
+  text: { type: "mrkdwn"; text: string };
+};
+
+export const sectionTexts = (blocks: unknown[]): string[] =>
+  blocks
+    .filter(
+      (b): b is SectionBlock =>
+        typeof b === "object" &&
+        b !== null &&
+        (b as { type?: string }).type === "section",
+    )
+    .map((b) => b.text.text);

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -260,8 +260,13 @@ describe("src/main", () => {
       expect(call[0]).toEqual("dummy_url");
       expect(call[1].includes("<@slack_user_1>")).toEqual(true);
       expect(call[1].includes("<review_comment_url|pr_title>")).toEqual(true);
-      expect(call[1].includes("> @github_user_1 LGTM!")).toEqual(true);
       expect(call[1].includes("by sender_github_username")).toEqual(true);
+      const bodySectionTexts = call[2].blocks
+        .filter((b: { type: string }) => b.type === "section")
+        .map((b: { text: { text: string } }) => b.text.text);
+      expect(bodySectionTexts).toContain("@github_user_1 LGTM!");
+      // body should not be quoted any more
+      expect(call[1].includes("> @github_user_1 LGTM!")).toEqual(false);
     });
 
     it("should not call postToSlack if requested_user is not listed in mapping", async () => {
@@ -469,7 +474,11 @@ describe("src/main", () => {
         "<https://github.com/abeyuya/github-actions-test/pull/11#pullrequestreview-787479727|Update mention-to-slack.yml>",
       );
       expect(call[1]).toMatch("by abeyuya");
-      expect(call[1]).toMatch(`> ${body}`);
+      const bodySectionTexts = call[2].blocks
+        .filter((b: { type: string }) => b.type === "section")
+        .map((b: { text: { text: string } }) => b.text.text);
+      expect(bodySectionTexts).toContain(body);
+      expect(call[1]).not.toMatch(`> ${body}`);
     });
 
     describe("when the reviewer is the PR author (self-review)", () => {

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../src/main.js";
 
 import { prApprovePayload } from "./fixture/real-payload-20211024-pr-approve.js";
+import { sectionTexts } from "./fixture/slackBlocks.js";
 
 vi.mock("@actions/core", async () => {
   const actual =
@@ -261,10 +262,7 @@ describe("src/main", () => {
       expect(call[1].includes("<@slack_user_1>")).toEqual(true);
       expect(call[1].includes("<review_comment_url|pr_title>")).toEqual(true);
       expect(call[1].includes("by sender_github_username")).toEqual(true);
-      const bodySectionTexts = call[2].blocks
-        .filter((b: { type: string }) => b.type === "section")
-        .map((b: { text: { text: string } }) => b.text.text);
-      expect(bodySectionTexts).toContain("@github_user_1 LGTM!");
+      expect(sectionTexts(call[2].blocks)).toContain("@github_user_1 LGTM!");
       // body should not be quoted any more
       expect(call[1].includes("> @github_user_1 LGTM!")).toEqual(false);
     });
@@ -430,17 +428,17 @@ describe("src/main", () => {
       {
         state: "approved",
         body: "approve comment",
-        expectedPhrase: "has been approved",
+        expectedPhrase: "has been approved by",
       },
       {
         state: "changes_requested",
         body: "please fix this",
-        expectedPhrase: "has been requested changes",
+        expectedPhrase: "has changes requested by",
       },
       {
         state: "commented",
         body: "just a comment",
-        expectedPhrase: "has received a review comment",
+        expectedPhrase: "received a review comment from",
       },
     ])("should send slack mention with $state wording", async ({
       state,
@@ -473,11 +471,8 @@ describe("src/main", () => {
       expect(call[1]).toMatch(
         "<https://github.com/abeyuya/github-actions-test/pull/11#pullrequestreview-787479727|Update mention-to-slack.yml>",
       );
-      expect(call[1]).toMatch("by abeyuya");
-      const bodySectionTexts = call[2].blocks
-        .filter((b: { type: string }) => b.type === "section")
-        .map((b: { text: { text: string } }) => b.text.text);
-      expect(bodySectionTexts).toContain(body);
+      expect(call[1]).toMatch("abeyuya");
+      expect(sectionTexts(call[2].blocks)).toContain(body);
       expect(call[1]).not.toMatch(`> ${body}`);
     });
 

--- a/__tests__/modules/slack.test.ts
+++ b/__tests__/modules/slack.test.ts
@@ -2,22 +2,11 @@ import {
   buildSlackErrorMessage,
   buildSlackPostMessage,
   buildSlackReviewSubmittedMessage,
+  CONTINUATION_SUFFIX,
+  SECTION_TEXT_LIMIT,
+  splitMrkdwnByLimit,
 } from "../../src/modules/slack.js";
-
-type SectionBlock = {
-  type: "section";
-  text: { type: "mrkdwn"; text: string };
-};
-
-const sectionTexts = (blocks: unknown[]): string[] =>
-  blocks
-    .filter(
-      (b): b is SectionBlock =>
-        typeof b === "object" &&
-        b !== null &&
-        (b as { type?: string }).type === "section",
-    )
-    .map((b) => b.text.text);
+import { sectionTexts } from "../fixture/slackBlocks.js";
 
 describe("modules/slack", () => {
   describe("buildSlackPostMessage", () => {
@@ -107,11 +96,11 @@ describe("modules/slack", () => {
 
   describe("buildSlackReviewSubmittedMessage", () => {
     it.each([
-      ["approved", "has been approved"],
-      ["changes_requested", "has been requested changes on"],
-      ["commented", "has received a review comment on"],
-      [undefined, "has received a review comment on"],
-    ] as const)("should compose headline for review state '%s'", (state, verb) => {
+      ["approved", "has been approved by reviewer_user"],
+      ["changes_requested", "has changes requested by reviewer_user"],
+      ["commented", "received a review comment from reviewer_user"],
+      [undefined, "received a review comment from reviewer_user"],
+    ] as const)("should compose headline for review state '%s'", (state, tail) => {
       const result = buildSlackReviewSubmittedMessage(
         "U_OWNER",
         "<https://example.com/pr/1|#42 PR1>",
@@ -120,7 +109,7 @@ describe("modules/slack", () => {
         "review body",
       );
 
-      const expectedHeadline = `<@U_OWNER> ${verb} <https://example.com/pr/1|#42 PR1> by reviewer_user.`;
+      const expectedHeadline = `<@U_OWNER> <https://example.com/pr/1|#42 PR1> ${tail}.`;
       expect(result.text).toEqual(expectedHeadline);
       const texts = sectionTexts(result.blocks);
       expect(texts[0]).toEqual(expectedHeadline);
@@ -169,6 +158,42 @@ describe("modules/slack", () => {
       expect(stackSection.startsWith("```")).toBe(true);
       expect(stackSection.endsWith("```")).toBe(true);
       expect(stackSection.includes("dummy error")).toBe(true);
+    });
+  });
+
+  describe("splitMrkdwnByLimit", () => {
+    it("should split a single line longer than the limit and mark intermediate chunks with (cont.)", () => {
+      const longLine = "a".repeat(SECTION_TEXT_LIMIT + 100);
+      const chunks = splitMrkdwnByLimit(longLine);
+
+      expect(chunks.length).toBeGreaterThanOrEqual(2);
+      for (const c of chunks) {
+        expect(c.length).toBeLessThanOrEqual(SECTION_TEXT_LIMIT);
+      }
+      for (let i = 0; i < chunks.length - 1; i += 1) {
+        expect(chunks[i].endsWith(CONTINUATION_SUFFIX)).toBe(true);
+      }
+      expect(chunks[chunks.length - 1].endsWith(CONTINUATION_SUFFIX)).toBe(
+        false,
+      );
+
+      const restored = chunks
+        .map((c, i) =>
+          i === chunks.length - 1
+            ? c
+            : c.slice(0, c.length - CONTINUATION_SUFFIX.length),
+        )
+        .join("");
+      expect(restored).toEqual(longLine);
+    });
+
+    it("should return the input untouched when within the limit", () => {
+      const text = "short text\nwith newline";
+      expect(splitMrkdwnByLimit(text)).toEqual([text]);
+    });
+
+    it("should return an empty array for an empty input", () => {
+      expect(splitMrkdwnByLimit("")).toEqual([]);
     });
   });
 });

--- a/__tests__/modules/slack.test.ts
+++ b/__tests__/modules/slack.test.ts
@@ -1,11 +1,27 @@
 import {
   buildSlackErrorMessage,
   buildSlackPostMessage,
+  buildSlackReviewSubmittedMessage,
 } from "../../src/modules/slack.js";
+
+type SectionBlock = {
+  type: "section";
+  text: { type: "mrkdwn"; text: string };
+};
+
+const sectionTexts = (blocks: unknown[]): string[] =>
+  blocks
+    .filter(
+      (b): b is SectionBlock =>
+        typeof b === "object" &&
+        b !== null &&
+        (b as { type?: string }).type === "section",
+    )
+    .map((b) => b.text.text);
 
 describe("modules/slack", () => {
   describe("buildSlackPostMessage", () => {
-    it("should include all info", () => {
+    it("should put only the headline in text and split header/body into blocks", () => {
       const result = buildSlackPostMessage(
         ["slackUser1"],
         "title",
@@ -14,52 +30,145 @@ describe("modules/slack", () => {
         "sender_github_username",
       );
 
-      expect(result).toEqual(
-        `<@slackUser1> has been mentioned at <link|title> by sender_github_username
-> message`,
-      );
+      const expectedHeadline =
+        "<@slackUser1> has been mentioned at <link|title> by sender_github_username";
+      expect(result.text).toEqual(expectedHeadline);
+      const texts = sectionTexts(result.blocks);
+      expect(texts[0]).toEqual(expectedHeadline);
+      expect(texts[1]).toEqual("message");
+      expect(
+        result.blocks.some((b) => (b as { type?: string }).type === "divider"),
+      ).toBe(true);
     });
 
-    it("should be correct format with blockquotes", () => {
+    it("should keep the body verbatim (no machine-added > prefix) even when it starts with > / contains --- / ##", () => {
+      const body = "> quoted line\n\n---\n\n## heading\n\nbody";
       const result = buildSlackPostMessage(
         ["slackUser1"],
         "title",
         "link",
-        "> message\nhello",
+        body,
         "sender_github_username",
       );
 
-      expect(result).toEqual(
-        `<@slackUser1> has been mentioned at <link|title> by sender_github_username
->
-> > message
-> hello`,
+      const texts = sectionTexts(result.blocks);
+      // body section が元の body と完全一致する = 機械的なプレフィックス付与なし
+      expect(texts).toContain(body);
+    });
+
+    it("should use 'have' for multiple mentions and join them with spaces", () => {
+      const result = buildSlackPostMessage(
+        ["slackUser1", "slackUser2"],
+        "title",
+        "link",
+        "body",
+        "sender_github_username",
+      );
+
+      expect(result.text).toEqual(
+        "<@slackUser1> <@slackUser2> have been mentioned at <link|title> by sender_github_username",
       );
     });
 
-    it("should be correct format with blockquotes2", () => {
+    it("should split bodies that exceed the Slack section limit into multiple sections each within 3000 chars", () => {
+      const body = "a".repeat(8000);
       const result = buildSlackPostMessage(
         ["slackUser1"],
         "title",
         "link",
-        "message\n> hello",
+        body,
         "sender_github_username",
       );
 
-      expect(result).toEqual(
-        `<@slackUser1> has been mentioned at <link|title> by sender_github_username
-> message
-> > hello`,
+      const texts = sectionTexts(result.blocks);
+      // header + 複数の body chunk
+      expect(texts.length).toBeGreaterThan(2);
+      for (const t of texts) {
+        expect(t.length).toBeLessThanOrEqual(3000);
+      }
+    });
+
+    it("should omit body section when github body is empty", () => {
+      const result = buildSlackPostMessage(
+        ["slackUser1"],
+        "title",
+        "link",
+        "",
+        "sender_github_username",
       );
+
+      const texts = sectionTexts(result.blocks);
+      expect(texts.length).toEqual(1);
+      expect(
+        result.blocks.some((b) => (b as { type?: string }).type === "divider"),
+      ).toBe(false);
+    });
+  });
+
+  describe("buildSlackReviewSubmittedMessage", () => {
+    it.each([
+      ["approved", "has been approved"],
+      ["changes_requested", "has been requested changes on"],
+      ["commented", "has received a review comment on"],
+      [undefined, "has received a review comment on"],
+    ] as const)("should compose headline for review state '%s'", (state, verb) => {
+      const result = buildSlackReviewSubmittedMessage(
+        "U_OWNER",
+        "<https://example.com/pr/1|#42 PR1>",
+        "reviewer_user",
+        state,
+        "review body",
+      );
+
+      const expectedHeadline = `<@U_OWNER> ${verb} <https://example.com/pr/1|#42 PR1> by reviewer_user.`;
+      expect(result.text).toEqual(expectedHeadline);
+      const texts = sectionTexts(result.blocks);
+      expect(texts[0]).toEqual(expectedHeadline);
+      expect(texts[1]).toEqual("review body");
+    });
+
+    it("should keep review body verbatim (no machine-added > prefix)", () => {
+      const body = "> quoted\n\n---\n\n## heading\n\nbody";
+      const result = buildSlackReviewSubmittedMessage(
+        "U_OWNER",
+        "<link|title>",
+        "reviewer_user",
+        "commented",
+        body,
+      );
+
+      const texts = sectionTexts(result.blocks);
+      expect(texts).toContain(body);
+    });
+
+    it("should omit body section when review body is empty or null", () => {
+      const result = buildSlackReviewSubmittedMessage(
+        "U_OWNER",
+        "<link|title>",
+        "reviewer_user",
+        "approved",
+        null,
+      );
+
+      const texts = sectionTexts(result.blocks);
+      expect(texts.length).toEqual(1);
     });
   });
 
   describe("buildSlackErrorMessage", () => {
-    it("should include all info", () => {
+    it("should expose short text fallback and put stack trace in a code-fenced section", () => {
       const e = new Error("dummy error");
+      e.stack = "Error: dummy error\n  at line";
       const result = buildSlackErrorMessage(e);
 
-      expect(result.includes("dummy error")).toEqual(true);
+      expect(result.text.includes("internal error")).toBe(true);
+      const texts = sectionTexts(result.blocks);
+      // headline section + stack section
+      expect(texts.length).toBeGreaterThanOrEqual(2);
+      const stackSection = texts[texts.length - 1];
+      expect(stackSection.startsWith("```")).toBe(true);
+      expect(stackSection.endsWith("```")).toBe(true);
+      expect(stackSection.includes("dummy error")).toBe(true);
     });
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ import {
 import {
   buildSlackErrorMessage,
   buildSlackPostMessage,
-  convertGithubTextToBlockquotesText,
+  buildSlackReviewSubmittedMessage,
   SlackRepositoryImpl,
 } from "./modules/slack.js";
 
@@ -138,7 +138,7 @@ export const execNormalMention = async (
     return;
   }
 
-  const message = buildSlackPostMessage(
+  const slackPayload = buildSlackPostMessage(
     slackIdsWithoutIgnore,
     info.title,
     info.url,
@@ -148,10 +148,15 @@ export const execNormalMention = async (
 
   const { slackWebhookUrl, iconUrl, botName } = allInputs;
 
-  const result = await slackClient.postToSlack(slackWebhookUrl, message, {
-    iconUrl,
-    botName,
-  });
+  const result = await slackClient.postToSlack(
+    slackWebhookUrl,
+    slackPayload.text,
+    {
+      iconUrl,
+      botName,
+      blocks: slackPayload.blocks,
+    },
+  );
 
   debug(["postToSlack result", JSON.stringify({ result }, null, 2)].join("\n"));
 };
@@ -194,30 +199,20 @@ export const execReviewSubmittedMention = async (
     return null;
   }
 
-  const blockquotesReviewBody = convertGithubTextToBlockquotesText(
-    info.body || "",
-  );
-
   const prLink = `<${info.url}|${info.title}>`;
-  const userMention = `<@${prOwnerSlackUserId}>`;
-  const headline = (() => {
-    switch (reviewState) {
-      case "approved":
-        return `${userMention} has been approved ${prLink} by ${reviewer}.`;
-      case "changes_requested":
-        return `${userMention} has been requested changes on ${prLink} by ${reviewer}.`;
-      default:
-        return `${userMention} has received a review comment on ${prLink} by ${reviewer}.`;
-    }
-  })();
-
-  const message = [headline, blockquotesReviewBody].join("\n");
+  const slackPayload = buildSlackReviewSubmittedMessage(
+    prOwnerSlackUserId,
+    prLink,
+    reviewer,
+    reviewState,
+    info.body,
+  );
   const { slackWebhookUrl, iconUrl, botName } = allInputs;
 
   const postSlackResult = await slackClient.postToSlack(
     slackWebhookUrl,
-    message,
-    { iconUrl, botName },
+    slackPayload.text,
+    { iconUrl, botName, blocks: slackPayload.blocks },
   );
 
   debug(
@@ -270,16 +265,17 @@ export const execPostError = async (
 ): Promise<void> => {
   const { runId } = allInputs;
   const currentJobUrl = runId ? buildCurrentJobUrl(runId) : undefined;
-  const message = buildSlackErrorMessage(error, currentJobUrl);
+  const slackPayload = buildSlackErrorMessage(error, currentJobUrl);
 
-  warning(message);
+  warning([slackPayload.text, error.stack || error.message].join("\n"));
 
   const { slackWebhookUrl, iconUrl, botName } = allInputs;
 
   try {
-    await slackClient.postToSlack(slackWebhookUrl, message, {
+    await slackClient.postToSlack(slackWebhookUrl, slackPayload.text, {
       iconUrl,
       botName,
+      blocks: slackPayload.blocks,
     });
   } catch (e) {
     const reason = e instanceof Error ? e.message : String(e);

--- a/src/modules/reviewReminder.ts
+++ b/src/modules/reviewReminder.ts
@@ -1,6 +1,11 @@
 import { warning } from "@actions/core";
 import type { getOctokit } from "@actions/github";
-import type { SlackPostPayload } from "./slack.js";
+import {
+  buildSection,
+  CONTINUATION_SUFFIX,
+  SECTION_TEXT_LIMIT,
+  type SlackPostPayload,
+} from "./slack.js";
 
 export type ApprovalState =
   | "approved"
@@ -35,9 +40,6 @@ type ReviewLike = {
 
 const APPROVAL_API_CONCURRENCY = 5;
 const LABEL_DISPLAY_LIMIT = 5;
-// Slack section block text.text の上限は 3000 文字。安全余白を取って分割閾値を決める。
-const SECTION_TEXT_LIMIT = 2800;
-const CONTINUATION_SUFFIX = " (cont.)";
 
 const mapWithConcurrency = async <T, R>(
   items: T[],
@@ -265,18 +267,9 @@ export const buildReviewReminderMessage = (
 
   const text = [headerText, "", entryTextSections.join("\n\n")].join("\n");
 
-  const blocks: unknown[] = [
-    {
-      type: "section",
-      text: { type: "mrkdwn", text: headerText },
-    },
-    { type: "divider" },
-  ];
+  const blocks: unknown[] = [buildSection(headerText), { type: "divider" }];
   for (const section of entryBlockTexts) {
-    blocks.push({
-      type: "section",
-      text: { type: "mrkdwn", text: section },
-    });
+    blocks.push(buildSection(section));
   }
 
   return { text, blocks };

--- a/src/modules/reviewReminder.ts
+++ b/src/modules/reviewReminder.ts
@@ -1,5 +1,6 @@
 import { warning } from "@actions/core";
 import type { getOctokit } from "@actions/github";
+import type { SlackPostPayload } from "./slack.js";
 
 export type ApprovalState =
   | "approved"
@@ -25,10 +26,7 @@ export type ReminderEntry = RawReminderEntry & {
   slackId?: string;
 };
 
-export type ReminderSlackPayload = {
-  text: string;
-  blocks: unknown[];
-};
+export type ReminderSlackPayload = SlackPostPayload;
 
 type ReviewLike = {
   user?: { login?: string | null } | null;

--- a/src/modules/slack.ts
+++ b/src/modules/slack.ts
@@ -106,11 +106,11 @@ export const buildSlackReviewSubmittedMessage = (
   const headline = (() => {
     switch (reviewState) {
       case "approved":
-        return `${userMention} has been approved ${prLink} by ${reviewer}.`;
+        return `${userMention} ${prLink} has been approved by ${reviewer}.`;
       case "changes_requested":
-        return `${userMention} has been requested changes on ${prLink} by ${reviewer}.`;
+        return `${userMention} ${prLink} has changes requested by ${reviewer}.`;
       default:
-        return `${userMention} has received a review comment on ${prLink} by ${reviewer}.`;
+        return `${userMention} ${prLink} received a review comment from ${reviewer}.`;
     }
   })();
 

--- a/src/modules/slack.ts
+++ b/src/modules/slack.ts
@@ -1,17 +1,82 @@
-export const convertGithubTextToBlockquotesText = (githubText: string) => {
-  const t = githubText
-    .split("\n")
-    .map((line, i) => {
-      // fix slack layout collapse problem when first line starts with blockquotes.
-      if (i === 0 && line.startsWith(">")) {
-        return `>\n> ${line}`;
+export type SlackPostPayload = {
+  text: string;
+  blocks: unknown[];
+};
+
+// Slack section block text.text の上限は 3000 文字。安全余白を取って分割閾値を決める。
+const SECTION_TEXT_LIMIT = 2800;
+const CONTINUATION_SUFFIX = " (cont.)";
+
+const splitMrkdwnByLimit = (
+  text: string,
+  limit: number = SECTION_TEXT_LIMIT,
+): string[] => {
+  if (text.length === 0) return [];
+  if (text.length <= limit) return [text];
+
+  const chunks: string[] = [];
+  const lines = text.split("\n");
+  let current = "";
+
+  const flushCurrent = () => {
+    if (current.length > 0) {
+      chunks.push(current);
+      current = "";
+    }
+  };
+
+  const pushLongLine = (line: string) => {
+    // 1 行が limit を超えるケースは文字数で強制分割する
+    let remaining = line;
+    while (remaining.length > 0) {
+      const room = limit - CONTINUATION_SUFFIX.length;
+      if (remaining.length <= limit) {
+        chunks.push(remaining);
+        remaining = "";
+      } else {
+        chunks.push(`${remaining.slice(0, room)}${CONTINUATION_SUFFIX}`);
+        remaining = remaining.slice(room);
       }
+    }
+  };
 
-      return `> ${line}`;
-    })
-    .join("\n");
+  for (const line of lines) {
+    if (line.length > limit) {
+      flushCurrent();
+      pushLongLine(line);
+      continue;
+    }
 
-  return t;
+    const candidate = current.length === 0 ? line : `${current}\n${line}`;
+    if (candidate.length > limit) {
+      flushCurrent();
+      current = line;
+    } else {
+      current = candidate;
+    }
+  }
+  flushCurrent();
+
+  return chunks;
+};
+
+const buildSection = (text: string) => ({
+  type: "section",
+  text: { type: "mrkdwn", text },
+});
+
+const buildHeaderAndBodyBlocks = (
+  headline: string,
+  body: string | null | undefined,
+): unknown[] => {
+  const blocks: unknown[] = [buildSection(headline)];
+  if (body && body.length > 0) {
+    blocks.push({ type: "divider" });
+    for (const chunk of splitMrkdwnByLimit(body)) {
+      blocks.push(buildSection(chunk));
+    }
+  }
+  return blocks;
 };
 
 export const buildSlackPostMessage = (
@@ -20,17 +85,40 @@ export const buildSlackPostMessage = (
   commentLink: string,
   githubBody: string,
   senderName: string,
-): string => {
+): SlackPostPayload => {
   const mentionBlock = slackIdsForMention.map((id) => `<@${id}>`).join(" ");
-  const body = convertGithubTextToBlockquotesText(githubBody);
+  const verb = slackIdsForMention.length === 1 ? "has" : "have";
+  const headline = `${mentionBlock} ${verb} been mentioned at <${commentLink}|${issueTitle}> by ${senderName}`;
 
-  const message = [
-    mentionBlock,
-    `${slackIdsForMention.length === 1 ? "has" : "have"}`,
-    `been mentioned at <${commentLink}|${issueTitle}> by ${senderName}`,
-  ].join(" ");
+  return {
+    text: headline,
+    blocks: buildHeaderAndBodyBlocks(headline, githubBody),
+  };
+};
 
-  return `${message}\n${body}`;
+export const buildSlackReviewSubmittedMessage = (
+  prOwnerSlackUserId: string,
+  prLink: string,
+  reviewer: string,
+  reviewState: string | undefined,
+  reviewBody: string | null | undefined,
+): SlackPostPayload => {
+  const userMention = `<@${prOwnerSlackUserId}>`;
+  const headline = (() => {
+    switch (reviewState) {
+      case "approved":
+        return `${userMention} has been approved ${prLink} by ${reviewer}.`;
+      case "changes_requested":
+        return `${userMention} has been requested changes on ${prLink} by ${reviewer}.`;
+      default:
+        return `${userMention} has received a review comment on ${prLink} by ${reviewer}.`;
+    }
+  })();
+
+  return {
+    text: headline,
+    blocks: buildHeaderAndBodyBlocks(headline, reviewBody),
+  };
 };
 
 const openIssueLink =
@@ -39,7 +127,7 @@ const openIssueLink =
 export const buildSlackErrorMessage = (
   error: Error,
   currentJobUrl?: string,
-): string => {
+): SlackPostPayload => {
   const jobTitle = "mention-to-slack action";
   const jobLinkMessage = currentJobUrl
     ? `<${currentJobUrl}|${jobTitle}>`
@@ -53,15 +141,22 @@ export const buildSlackErrorMessage = (
     `${openIssueLink}?title=${error.message}&body=${issueBody}`,
   );
 
-  return [
+  const headline = [
     `❗ An internal error occurred in ${jobLinkMessage}`,
     "(but action didn't fail as this action is not critical).",
     `To solve the problem, please <${link}|open an issue>`,
-    "",
-    "```",
-    error.stack || error.message,
-    "```",
   ].join("\n");
+
+  const stack = error.stack || error.message;
+  const blocks: unknown[] = [buildSection(headline), { type: "divider" }];
+  for (const chunk of splitMrkdwnByLimit(stack)) {
+    blocks.push(buildSection(["```", chunk, "```"].join("\n")));
+  }
+
+  return {
+    text: `❗ An internal error occurred in ${jobTitle}`,
+    blocks,
+  };
 };
 
 export type SlackOption = {

--- a/src/modules/slack.ts
+++ b/src/modules/slack.ts
@@ -4,10 +4,10 @@ export type SlackPostPayload = {
 };
 
 // Slack section block text.text の上限は 3000 文字。安全余白を取って分割閾値を決める。
-const SECTION_TEXT_LIMIT = 2800;
-const CONTINUATION_SUFFIX = " (cont.)";
+export const SECTION_TEXT_LIMIT = 2800;
+export const CONTINUATION_SUFFIX = " (cont.)";
 
-const splitMrkdwnByLimit = (
+export const splitMrkdwnByLimit = (
   text: string,
   limit: number = SECTION_TEXT_LIMIT,
 ): string[] => {
@@ -26,10 +26,9 @@ const splitMrkdwnByLimit = (
   };
 
   const pushLongLine = (line: string) => {
-    // 1 行が limit を超えるケースは文字数で強制分割する
+    const room = limit - CONTINUATION_SUFFIX.length;
     let remaining = line;
     while (remaining.length > 0) {
-      const room = limit - CONTINUATION_SUFFIX.length;
       if (remaining.length <= limit) {
         chunks.push(remaining);
         remaining = "";
@@ -60,7 +59,7 @@ const splitMrkdwnByLimit = (
   return chunks;
 };
 
-const buildSection = (text: string) => ({
+export const buildSection = (text: string) => ({
   type: "section",
   text: { type: "mrkdwn", text },
 });


### PR DESCRIPTION
## 背景

GitHub のレビュー/コメント本文を Slack に流す際、本文の Markdown 構造によって表示が崩れていました。具体的には:

- 元コメントの先頭行が `>` で始まると、既存の `convertGithubTextToBlockquotesText` の特殊処理 (`>\n> ${line}`) が走り、Slack 上に「空の `>` 行 + `> > ...` (二重引用)」が現れる
- 本文中の空行・`---`・`##` などが含まれると、各行に `> ` を機械的に付ける現方式では Slack の引用ブロックが分断され、`---` が水平線扱いになり、`##` がプレーンテキストとして残り、見栄えが崩れる
- GitHub Markdown と Slack mrkdwn の互換性が低く、`> ` を機械的に貼るだけでは安定しない

## 変更内容

- 全 Slack 投稿 (通常メンション / Review Submitted / エラー通知) を **Block Kit (`blocks`)** に切り替え。本文は section block の mrkdwn にそのまま貼り、`> ` プレフィックスの機械的付与をやめる
- `text` フィールドは Slack デスクトップ通知用のフォールバックとして headline のみを残す
- 既存の Review Reminder (`reviewReminder.ts`) と方針を完全に揃え、共通定数 (`SECTION_TEXT_LIMIT`, `CONTINUATION_SUFFIX`) と `buildSection` を `slack.ts` 側に集約。`reviewReminder.ts` の重複定義は削除
- 3000 文字超の本文は section ごとに分割 (`splitMrkdwnByLimit`、長 1 行は `(cont.)` サフィックス付きで強制分割)
- 不要になった `convertGithubTextToBlockquotesText` は削除
- `buildSlackReviewSubmittedMessage` の headline 英語表現を文法的に自然な形に修正
  - 旧: `<@owner> has been approved <link> by reviewer.`
  - 新: `<@owner> <link> has been approved by reviewer.`
- 既存テストの `> body` 前提アサーションを blocks ベースに書き換え、3000 文字制限分割・空 body のスキップ・長行 `(cont.)` パスなどのケースを追加
- テスト用の `SectionBlock` 型と `sectionTexts` ヘルパを `__tests__/fixture/slackBlocks.ts` に切り出し共通化

## Test plan

- [x] `npm test` (vitest run) — 114 passed
- [x] `npm run lint` (tsc --noEmit + biome check) — pass
- [ ] 実 Slack 投稿の目視確認 (PR マージ後、actions 実行で確認)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTq3pVUAzNbPciTKLWkM3h)_