### PR TITLE
Wrap Slack notification body in grey-colored attachment for blockquote look

### DIFF
--- a/__tests__/fixture/slackBlocks.ts
+++ b/__tests__/fixture/slackBlocks.ts
@@ -3,6 +3,11 @@ export type SectionBlock = {
   text: { type: "mrkdwn"; text: string };
 };
 
+export type QuoteAttachment = {
+  color: string;
+  blocks: unknown[];
+};
+
 export const sectionTexts = (blocks: unknown[]): string[] =>
   blocks
     .filter(
@@ -12,3 +17,10 @@ export const sectionTexts = (blocks: unknown[]): string[] =>
         (b as { type?: string }).type === "section",
     )
     .map((b) => b.text.text);
+
+export const attachmentSectionTexts = (
+  attachments: unknown[] | undefined,
+): string[][] =>
+  (attachments ?? []).map((a) =>
+    sectionTexts((a as { blocks?: unknown[] }).blocks ?? []),
+  );

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../src/main.js";
 
 import { prApprovePayload } from "./fixture/real-payload-20211024-pr-approve.js";
-import { sectionTexts } from "./fixture/slackBlocks.js";
+import { attachmentSectionTexts } from "./fixture/slackBlocks.js";
 
 vi.mock("@actions/core", async () => {
   const actual =
@@ -262,9 +262,11 @@ describe("src/main", () => {
       expect(call[1].includes("<@slack_user_1>")).toEqual(true);
       expect(call[1].includes("<review_comment_url|pr_title>")).toEqual(true);
       expect(call[1].includes("by sender_github_username")).toEqual(true);
-      expect(sectionTexts(call[2].blocks)).toContain("@github_user_1 LGTM!");
-      // body should not be quoted any more
+      // body should not be quoted with > any more, and should live in an attachment
       expect(call[1].includes("> @github_user_1 LGTM!")).toEqual(false);
+      expect(attachmentSectionTexts(call[2].attachments)).toEqual([
+        ["@github_user_1 LGTM!"],
+      ]);
     });
 
     it("should not call postToSlack if requested_user is not listed in mapping", async () => {
@@ -472,7 +474,7 @@ describe("src/main", () => {
         "<https://github.com/abeyuya/github-actions-test/pull/11#pullrequestreview-787479727|Update mention-to-slack.yml>",
       );
       expect(call[1]).toMatch("abeyuya");
-      expect(sectionTexts(call[2].blocks)).toContain(body);
+      expect(attachmentSectionTexts(call[2].attachments)).toEqual([[body]]);
       expect(call[1]).not.toMatch(`> ${body}`);
     });
 

--- a/__tests__/modules/slack.test.ts
+++ b/__tests__/modules/slack.test.ts
@@ -30,11 +30,11 @@ describe("modules/slack", () => {
       expect(result.text).toEqual(expectedHeadline);
       expect(sectionTexts(result.blocks)).toEqual([expectedHeadline]);
 
-      const attachments = result.attachments;
-      expect(attachments).toBeDefined();
-      expect(attachments?.length).toEqual(1);
-      expect((attachments?.[0] as QuoteAttachment).color).toEqual(QUOTE_COLOR);
-      expect(attachmentSectionTexts(attachments)).toEqual([["message"]]);
+      expect(result.attachments.length).toEqual(1);
+      expect((result.attachments[0] as QuoteAttachment).color).toEqual(
+        QUOTE_COLOR,
+      );
+      expect(attachmentSectionTexts(result.attachments)).toEqual([["message"]]);
     });
 
     it("should keep the body verbatim (no machine-added > prefix) even when it starts with > / contains --- / ##", () => {
@@ -90,7 +90,7 @@ describe("modules/slack", () => {
         "sender_github_username",
       );
 
-      expect(result.attachments).toBeUndefined();
+      expect(result.attachments).toEqual([]);
       expect(sectionTexts(result.blocks)).toEqual([result.text]);
     });
   });
@@ -140,7 +140,7 @@ describe("modules/slack", () => {
         null,
       );
 
-      expect(result.attachments).toBeUndefined();
+      expect(result.attachments).toEqual([]);
     });
   });
 
@@ -152,7 +152,7 @@ describe("modules/slack", () => {
 
       expect(result.text.includes("internal error")).toBe(true);
       expect(sectionTexts(result.blocks).length).toEqual(1);
-      expect((result.attachments?.[0] as QuoteAttachment).color).toEqual(
+      expect((result.attachments[0] as QuoteAttachment).color).toEqual(
         QUOTE_COLOR,
       );
       const stackSection = attachmentSectionTexts(result.attachments)[0][0];

--- a/__tests__/modules/slack.test.ts
+++ b/__tests__/modules/slack.test.ts
@@ -6,11 +6,17 @@ import {
   SECTION_TEXT_LIMIT,
   splitMrkdwnByLimit,
 } from "../../src/modules/slack.js";
-import { sectionTexts } from "../fixture/slackBlocks.js";
+import {
+  attachmentSectionTexts,
+  type QuoteAttachment,
+  sectionTexts,
+} from "../fixture/slackBlocks.js";
+
+const QUOTE_COLOR = "#cccccc";
 
 describe("modules/slack", () => {
   describe("buildSlackPostMessage", () => {
-    it("should put only the headline in text and split header/body into blocks", () => {
+    it("should keep only the headline in text/blocks and put the body in a grey-colored attachment", () => {
       const result = buildSlackPostMessage(
         ["slackUser1"],
         "title",
@@ -22,12 +28,13 @@ describe("modules/slack", () => {
       const expectedHeadline =
         "<@slackUser1> has been mentioned at <link|title> by sender_github_username";
       expect(result.text).toEqual(expectedHeadline);
-      const texts = sectionTexts(result.blocks);
-      expect(texts[0]).toEqual(expectedHeadline);
-      expect(texts[1]).toEqual("message");
-      expect(
-        result.blocks.some((b) => (b as { type?: string }).type === "divider"),
-      ).toBe(true);
+      expect(sectionTexts(result.blocks)).toEqual([expectedHeadline]);
+
+      const attachments = result.attachments;
+      expect(attachments).toBeDefined();
+      expect(attachments?.length).toEqual(1);
+      expect((attachments?.[0] as QuoteAttachment).color).toEqual(QUOTE_COLOR);
+      expect(attachmentSectionTexts(attachments)).toEqual([["message"]]);
     });
 
     it("should keep the body verbatim (no machine-added > prefix) even when it starts with > / contains --- / ##", () => {
@@ -40,9 +47,7 @@ describe("modules/slack", () => {
         "sender_github_username",
       );
 
-      const texts = sectionTexts(result.blocks);
-      // body section が元の body と完全一致する = 機械的なプレフィックス付与なし
-      expect(texts).toContain(body);
+      expect(attachmentSectionTexts(result.attachments)).toEqual([[body]]);
     });
 
     it("should use 'have' for multiple mentions and join them with spaces", () => {
@@ -59,7 +64,7 @@ describe("modules/slack", () => {
       );
     });
 
-    it("should split bodies that exceed the Slack section limit into multiple sections each within 3000 chars", () => {
+    it("should split bodies that exceed the Slack section limit into multiple attachment sections each within 3000 chars", () => {
       const body = "a".repeat(8000);
       const result = buildSlackPostMessage(
         ["slackUser1"],
@@ -69,15 +74,14 @@ describe("modules/slack", () => {
         "sender_github_username",
       );
 
-      const texts = sectionTexts(result.blocks);
-      // header + 複数の body chunk
-      expect(texts.length).toBeGreaterThan(2);
-      for (const t of texts) {
+      const chunks = attachmentSectionTexts(result.attachments)[0];
+      expect(chunks.length).toBeGreaterThanOrEqual(3);
+      for (const t of chunks) {
         expect(t.length).toBeLessThanOrEqual(3000);
       }
     });
 
-    it("should omit body section when github body is empty", () => {
+    it("should omit attachments when github body is empty", () => {
       const result = buildSlackPostMessage(
         ["slackUser1"],
         "title",
@@ -86,11 +90,8 @@ describe("modules/slack", () => {
         "sender_github_username",
       );
 
-      const texts = sectionTexts(result.blocks);
-      expect(texts.length).toEqual(1);
-      expect(
-        result.blocks.some((b) => (b as { type?: string }).type === "divider"),
-      ).toBe(false);
+      expect(result.attachments).toBeUndefined();
+      expect(sectionTexts(result.blocks)).toEqual([result.text]);
     });
   });
 
@@ -111,9 +112,10 @@ describe("modules/slack", () => {
 
       const expectedHeadline = `<@U_OWNER> <https://example.com/pr/1|#42 PR1> ${tail}.`;
       expect(result.text).toEqual(expectedHeadline);
-      const texts = sectionTexts(result.blocks);
-      expect(texts[0]).toEqual(expectedHeadline);
-      expect(texts[1]).toEqual("review body");
+      expect(sectionTexts(result.blocks)).toEqual([expectedHeadline]);
+      expect(attachmentSectionTexts(result.attachments)).toEqual([
+        ["review body"],
+      ]);
     });
 
     it("should keep review body verbatim (no machine-added > prefix)", () => {
@@ -126,11 +128,10 @@ describe("modules/slack", () => {
         body,
       );
 
-      const texts = sectionTexts(result.blocks);
-      expect(texts).toContain(body);
+      expect(attachmentSectionTexts(result.attachments)).toEqual([[body]]);
     });
 
-    it("should omit body section when review body is empty or null", () => {
+    it("should omit attachments when review body is empty or null", () => {
       const result = buildSlackReviewSubmittedMessage(
         "U_OWNER",
         "<link|title>",
@@ -139,22 +140,22 @@ describe("modules/slack", () => {
         null,
       );
 
-      const texts = sectionTexts(result.blocks);
-      expect(texts.length).toEqual(1);
+      expect(result.attachments).toBeUndefined();
     });
   });
 
   describe("buildSlackErrorMessage", () => {
-    it("should expose short text fallback and put stack trace in a code-fenced section", () => {
+    it("should expose short text fallback and put stack trace in a grey-colored attachment", () => {
       const e = new Error("dummy error");
       e.stack = "Error: dummy error\n  at line";
       const result = buildSlackErrorMessage(e);
 
       expect(result.text.includes("internal error")).toBe(true);
-      const texts = sectionTexts(result.blocks);
-      // headline section + stack section
-      expect(texts.length).toBeGreaterThanOrEqual(2);
-      const stackSection = texts[texts.length - 1];
+      expect(sectionTexts(result.blocks).length).toEqual(1);
+      expect((result.attachments?.[0] as QuoteAttachment).color).toEqual(
+        QUOTE_COLOR,
+      );
+      const stackSection = attachmentSectionTexts(result.attachments)[0][0];
       expect(stackSection.startsWith("```")).toBe(true);
       expect(stackSection.endsWith("```")).toBe(true);
       expect(stackSection.includes("dummy error")).toBe(true);

--- a/src/main.ts
+++ b/src/main.ts
@@ -155,6 +155,7 @@ export const execNormalMention = async (
       iconUrl,
       botName,
       blocks: slackPayload.blocks,
+      attachments: slackPayload.attachments,
     },
   );
 
@@ -212,7 +213,12 @@ export const execReviewSubmittedMention = async (
   const postSlackResult = await slackClient.postToSlack(
     slackWebhookUrl,
     slackPayload.text,
-    { iconUrl, botName, blocks: slackPayload.blocks },
+    {
+      iconUrl,
+      botName,
+      blocks: slackPayload.blocks,
+      attachments: slackPayload.attachments,
+    },
   );
 
   debug(
@@ -276,6 +282,7 @@ export const execPostError = async (
       iconUrl,
       botName,
       blocks: slackPayload.blocks,
+      attachments: slackPayload.attachments,
     });
   } catch (e) {
     const reason = e instanceof Error ? e.message : String(e);

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,8 +21,22 @@ import {
   buildSlackErrorMessage,
   buildSlackPostMessage,
   buildSlackReviewSubmittedMessage,
+  type SlackPostPayload,
   SlackRepositoryImpl,
 } from "./modules/slack.js";
+
+const postSlackPayload = (
+  slackClient: Pick<typeof SlackRepositoryImpl, "postToSlack">,
+  webhookUrl: string,
+  payload: SlackPostPayload,
+  options: { iconUrl?: string; botName?: string },
+): Promise<string> =>
+  slackClient.postToSlack(webhookUrl, payload.text, {
+    iconUrl: options.iconUrl,
+    botName: options.botName,
+    blocks: payload.blocks,
+    attachments: payload.attachments,
+  });
 
 export type ActionType = "realtime-alert" | "scheduled-reminder";
 export type AllInputs = {
@@ -148,15 +162,11 @@ export const execNormalMention = async (
 
   const { slackWebhookUrl, iconUrl, botName } = allInputs;
 
-  const result = await slackClient.postToSlack(
+  const result = await postSlackPayload(
+    slackClient,
     slackWebhookUrl,
-    slackPayload.text,
-    {
-      iconUrl,
-      botName,
-      blocks: slackPayload.blocks,
-      attachments: slackPayload.attachments,
-    },
+    slackPayload,
+    { iconUrl, botName },
   );
 
   debug(["postToSlack result", JSON.stringify({ result }, null, 2)].join("\n"));
@@ -210,15 +220,11 @@ export const execReviewSubmittedMention = async (
   );
   const { slackWebhookUrl, iconUrl, botName } = allInputs;
 
-  const postSlackResult = await slackClient.postToSlack(
+  const postSlackResult = await postSlackPayload(
+    slackClient,
     slackWebhookUrl,
-    slackPayload.text,
-    {
-      iconUrl,
-      botName,
-      blocks: slackPayload.blocks,
-      attachments: slackPayload.attachments,
-    },
+    slackPayload,
+    { iconUrl, botName },
   );
 
   debug(
@@ -252,10 +258,9 @@ export const execReviewReminder = async (
   }
 
   const { slackWebhookUrl, iconUrl, botName } = allInputs;
-  await slackClient.postToSlack(slackWebhookUrl, payload.text, {
+  await postSlackPayload(slackClient, slackWebhookUrl, payload, {
     iconUrl,
     botName,
-    blocks: payload.blocks,
   });
 };
 
@@ -278,11 +283,9 @@ export const execPostError = async (
   const { slackWebhookUrl, iconUrl, botName } = allInputs;
 
   try {
-    await slackClient.postToSlack(slackWebhookUrl, slackPayload.text, {
+    await postSlackPayload(slackClient, slackWebhookUrl, slackPayload, {
       iconUrl,
       botName,
-      blocks: slackPayload.blocks,
-      attachments: slackPayload.attachments,
     });
   } catch (e) {
     const reason = e instanceof Error ? e.message : String(e);

--- a/src/modules/reviewReminder.ts
+++ b/src/modules/reviewReminder.ts
@@ -272,5 +272,5 @@ export const buildReviewReminderMessage = (
     blocks.push(buildSection(section));
   }
 
-  return { text, blocks };
+  return { text, blocks, attachments: [] };
 };

--- a/src/modules/slack.ts
+++ b/src/modules/slack.ts
@@ -1,7 +1,7 @@
 export type SlackPostPayload = {
   text: string;
   blocks: unknown[];
-  attachments?: unknown[];
+  attachments: unknown[];
 };
 
 // Slack section block text.text の上限は 3000 文字。安全余白を取って分割閾値を決める。
@@ -67,25 +67,25 @@ export const buildSection = (text: string) => ({
   text: { type: "mrkdwn", text },
 });
 
-const buildQuoteAttachment = (chunks: string[]): unknown | null => {
-  if (chunks.length === 0) return null;
-  return {
-    color: QUOTE_ATTACHMENT_COLOR,
-    blocks: chunks.map((chunk) => buildSection(chunk)),
-  };
+const buildQuoteAttachments = (chunks: string[]): unknown[] => {
+  if (chunks.length === 0) return [];
+  return [
+    {
+      color: QUOTE_ATTACHMENT_COLOR,
+      blocks: chunks.map((chunk) => buildSection(chunk)),
+    },
+  ];
 };
 
 const buildHeaderWithQuotedBody = (
   headline: string,
   body: string | null | undefined,
 ): SlackPostPayload => {
-  const blocks: unknown[] = [buildSection(headline)];
   const bodyChunks = body && body.length > 0 ? splitMrkdwnByLimit(body) : [];
-  const attachment = buildQuoteAttachment(bodyChunks);
   return {
     text: headline,
-    blocks,
-    ...(attachment ? { attachments: [attachment] } : {}),
+    blocks: [buildSection(headline)],
+    attachments: buildQuoteAttachments(bodyChunks),
   };
 };
 
@@ -153,12 +153,11 @@ export const buildSlackErrorMessage = (
   const stackChunks = splitMrkdwnByLimit(stack).map((chunk) =>
     ["```", chunk, "```"].join("\n"),
   );
-  const attachment = buildQuoteAttachment(stackChunks);
 
   return {
     text: `❗ An internal error occurred in ${jobTitle}`,
     blocks: [buildSection(headline)],
-    ...(attachment ? { attachments: [attachment] } : {}),
+    attachments: buildQuoteAttachments(stackChunks),
   };
 };
 

--- a/src/modules/slack.ts
+++ b/src/modules/slack.ts
@@ -1,11 +1,14 @@
 export type SlackPostPayload = {
   text: string;
   blocks: unknown[];
+  attachments?: unknown[];
 };
 
 // Slack section block text.text の上限は 3000 文字。安全余白を取って分割閾値を決める。
 export const SECTION_TEXT_LIMIT = 2800;
 export const CONTINUATION_SUFFIX = " (cont.)";
+// GitHub 公式 bot に近い、引用ブロックの縦線を模した中間グレー
+const QUOTE_ATTACHMENT_COLOR = "#cccccc";
 
 export const splitMrkdwnByLimit = (
   text: string,
@@ -64,18 +67,26 @@ export const buildSection = (text: string) => ({
   text: { type: "mrkdwn", text },
 });
 
-const buildHeaderAndBodyBlocks = (
+const buildQuoteAttachment = (chunks: string[]): unknown | null => {
+  if (chunks.length === 0) return null;
+  return {
+    color: QUOTE_ATTACHMENT_COLOR,
+    blocks: chunks.map((chunk) => buildSection(chunk)),
+  };
+};
+
+const buildHeaderWithQuotedBody = (
   headline: string,
   body: string | null | undefined,
-): unknown[] => {
+): SlackPostPayload => {
   const blocks: unknown[] = [buildSection(headline)];
-  if (body && body.length > 0) {
-    blocks.push({ type: "divider" });
-    for (const chunk of splitMrkdwnByLimit(body)) {
-      blocks.push(buildSection(chunk));
-    }
-  }
-  return blocks;
+  const bodyChunks = body && body.length > 0 ? splitMrkdwnByLimit(body) : [];
+  const attachment = buildQuoteAttachment(bodyChunks);
+  return {
+    text: headline,
+    blocks,
+    ...(attachment ? { attachments: [attachment] } : {}),
+  };
 };
 
 export const buildSlackPostMessage = (
@@ -88,11 +99,7 @@ export const buildSlackPostMessage = (
   const mentionBlock = slackIdsForMention.map((id) => `<@${id}>`).join(" ");
   const verb = slackIdsForMention.length === 1 ? "has" : "have";
   const headline = `${mentionBlock} ${verb} been mentioned at <${commentLink}|${issueTitle}> by ${senderName}`;
-
-  return {
-    text: headline,
-    blocks: buildHeaderAndBodyBlocks(headline, githubBody),
-  };
+  return buildHeaderWithQuotedBody(headline, githubBody);
 };
 
 export const buildSlackReviewSubmittedMessage = (
@@ -113,11 +120,7 @@ export const buildSlackReviewSubmittedMessage = (
         return `${userMention} ${prLink} received a review comment from ${reviewer}.`;
     }
   })();
-
-  return {
-    text: headline,
-    blocks: buildHeaderAndBodyBlocks(headline, reviewBody),
-  };
+  return buildHeaderWithQuotedBody(headline, reviewBody);
 };
 
 const openIssueLink =
@@ -147,14 +150,15 @@ export const buildSlackErrorMessage = (
   ].join("\n");
 
   const stack = error.stack || error.message;
-  const blocks: unknown[] = [buildSection(headline), { type: "divider" }];
-  for (const chunk of splitMrkdwnByLimit(stack)) {
-    blocks.push(buildSection(["```", chunk, "```"].join("\n")));
-  }
+  const stackChunks = splitMrkdwnByLimit(stack).map((chunk) =>
+    ["```", chunk, "```"].join("\n"),
+  );
+  const attachment = buildQuoteAttachment(stackChunks);
 
   return {
     text: `❗ An internal error occurred in ${jobTitle}`,
-    blocks,
+    blocks: [buildSection(headline)],
+    ...(attachment ? { attachments: [attachment] } : {}),
   };
 };
 
@@ -162,6 +166,7 @@ export type SlackOption = {
   iconUrl?: string;
   botName?: string;
   blocks?: unknown[];
+  attachments?: unknown[];
 };
 
 type SlackPostParam = {
@@ -171,6 +176,7 @@ type SlackPostParam = {
   icon_url?: string;
   icon_emoji?: string;
   blocks?: unknown[];
+  attachments?: unknown[];
 };
 
 const defaultBotName = "Github Mention To Slack";
@@ -205,6 +211,10 @@ export const SlackRepositoryImpl = {
 
     if (options?.blocks && options.blocks.length > 0) {
       slackPostParam.blocks = options.blocks;
+    }
+
+    if (options?.attachments && options.attachments.length > 0) {
+      slackPostParam.attachments = options.attachments;
     }
 
     const response = await fetch(webhookUrl, {

--- a/src/modules/slack.ts
+++ b/src/modules/slack.ts
@@ -81,7 +81,7 @@ const buildHeaderWithQuotedBody = (
   headline: string,
   body: string | null | undefined,
 ): SlackPostPayload => {
-  const bodyChunks = body && body.length > 0 ? splitMrkdwnByLimit(body) : [];
+  const bodyChunks = body ? splitMrkdwnByLimit(body) : [];
   return {
     text: headline,
     blocks: [buildSection(headline)],


### PR DESCRIPTION
## 背景

PR #371 で Slack 通知を Block Kit (`blocks`) に切り替えたが、本文 (引用部分) が単なる section block として表示されるため、GitHub 公式 bot のような「グレーの縦線付き引用」の見た目が出ない問題が残っていた。

## 変更内容

Slack の **attachments の `color` バー** を併用し、本文を `color: "#cccccc"` の attachment 内 blocks として配置することで、headline + グレー縦線付き引用本文という見た目に改善する。Markdown 構造による崩れは Block Kit 利用で引き続き回避できる。

- `SlackPostPayload` に `attachments: unknown[]` (required) を追加。`SlackOption` / `SlackPostParam` / `postToSlack` も対応
- `slack.ts` に `buildQuoteAttachments(chunks): unknown[]` / `buildHeaderWithQuotedBody(headline, body)` ヘルパを新設。`buildSlackPostMessage` / `buildSlackReviewSubmittedMessage` / `buildSlackErrorMessage` を統一構造に再整理 (本文は attachments、headline は blocks)
- `reviewReminder.ts` の `buildReviewReminderMessage` も `attachments: []` を返すよう揃え、`SlackPostPayload` シェイプを完全準拠
- `main.ts` に private ヘルパ `postSlackPayload(slackClient, url, payload, options)` を新設。`execNormalMention` / `execReviewSubmittedMention` / `execReviewReminder` / `execPostError` の 4 箇所を 1 行に統一し、`text` / `blocks` / `attachments` を呼び出し側で手分解するボイラープレートを解消
- テストヘルパ `attachmentSectionTexts` / `QuoteAttachment` 型を `__tests__/fixture/slackBlocks.ts` に追加。既存テストの assertion を attachments 構造に書き換え、color が `#cccccc` であること / 空 body 時に attachments が空であることも検証

## Test plan

- [x] `npm test` (vitest run) — 114 passed
- [x] `npm run lint` (tsc --noEmit + biome check) — pass
- [ ] 実 Slack 投稿の目視確認 (PR マージ後、actions 実行で確認)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTq3pVUAzNbPciTKLWkM3h)_