### PR TITLE
Fix broken buildSlackCommentToAuthorMessage and align attachment color drift

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -588,7 +588,9 @@ describe("src/main", () => {
       expect(call[1]).toMatch("<@pr_author_slack>");
       expect(call[1]).toMatch("received a comment from commenter_github");
       expect(call[1]).toMatch("<comment_url|pr_title>");
-      expect(sectionTexts(call[2].blocks)).toContain("looks good");
+      expect(attachmentSectionTexts(call[2].attachments)).toEqual([
+        ["looks good"],
+      ]);
     });
 
     it("should not notify for a pull_request_review_comment (delegated to execReviewSubmittedMention)", async () => {

--- a/__tests__/modules/slack.test.ts
+++ b/__tests__/modules/slack.test.ts
@@ -13,7 +13,7 @@ import {
   sectionTexts,
 } from "../fixture/slackBlocks.js";
 
-const QUOTE_COLOR = "#cccccc";
+const QUOTE_COLOR = "#35373b";
 
 describe("modules/slack", () => {
   describe("buildSlackPostMessage", () => {
@@ -146,7 +146,7 @@ describe("modules/slack", () => {
   });
 
   describe("buildSlackCommentToAuthorMessage", () => {
-    it("should compose headline with PR link and commenter, and put body in a section", () => {
+    it("should keep only the headline in text/blocks and put the body in a grey-colored attachment", () => {
       const result = buildSlackCommentToAuthorMessage(
         "U_AUTHOR",
         "<https://example.com/pr/1|#42 PR1>",
@@ -157,12 +157,18 @@ describe("modules/slack", () => {
       const expectedHeadline =
         "<@U_AUTHOR> <https://example.com/pr/1|#42 PR1> received a comment from commenter_user.";
       expect(result.text).toEqual(expectedHeadline);
-      const texts = sectionTexts(result.blocks);
-      expect(texts[0]).toEqual(expectedHeadline);
-      expect(texts[1]).toEqual("looks good");
+      expect(sectionTexts(result.blocks)).toEqual([expectedHeadline]);
+
+      expect(result.attachments.length).toEqual(1);
+      expect((result.attachments[0] as QuoteAttachment).color).toEqual(
+        QUOTE_COLOR,
+      );
+      expect(attachmentSectionTexts(result.attachments)).toEqual([
+        ["looks good"],
+      ]);
     });
 
-    it("should omit body section when the comment body is empty or null", () => {
+    it("should omit attachments when the comment body is empty or null", () => {
       const result = buildSlackCommentToAuthorMessage(
         "U_AUTHOR",
         "<link|title>",
@@ -170,8 +176,8 @@ describe("modules/slack", () => {
         null,
       );
 
-      const texts = sectionTexts(result.blocks);
-      expect(texts.length).toEqual(1);
+      expect(result.attachments).toEqual([]);
+      expect(sectionTexts(result.blocks)).toEqual([result.text]);
     });
 
     it("should keep comment body verbatim (no machine-added > prefix)", () => {
@@ -183,8 +189,7 @@ describe("modules/slack", () => {
         body,
       );
 
-      const texts = sectionTexts(result.blocks);
-      expect(texts).toContain(body);
+      expect(attachmentSectionTexts(result.attachments)).toEqual([[body]]);
     });
   });
 

--- a/__tests__/modules/slack.test.ts
+++ b/__tests__/modules/slack.test.ts
@@ -4,6 +4,7 @@ import {
   buildSlackPostMessage,
   buildSlackReviewSubmittedMessage,
   CONTINUATION_SUFFIX,
+  QUOTE_ATTACHMENT_COLOR,
   SECTION_TEXT_LIMIT,
   splitMrkdwnByLimit,
 } from "../../src/modules/slack.js";
@@ -12,8 +13,6 @@ import {
   type QuoteAttachment,
   sectionTexts,
 } from "../fixture/slackBlocks.js";
-
-const QUOTE_COLOR = "#35373b";
 
 describe("modules/slack", () => {
   describe("buildSlackPostMessage", () => {
@@ -33,7 +32,7 @@ describe("modules/slack", () => {
 
       expect(result.attachments.length).toEqual(1);
       expect((result.attachments[0] as QuoteAttachment).color).toEqual(
-        QUOTE_COLOR,
+        QUOTE_ATTACHMENT_COLOR,
       );
       expect(attachmentSectionTexts(result.attachments)).toEqual([["message"]]);
     });
@@ -161,7 +160,7 @@ describe("modules/slack", () => {
 
       expect(result.attachments.length).toEqual(1);
       expect((result.attachments[0] as QuoteAttachment).color).toEqual(
-        QUOTE_COLOR,
+        QUOTE_ATTACHMENT_COLOR,
       );
       expect(attachmentSectionTexts(result.attachments)).toEqual([
         ["looks good"],
@@ -202,7 +201,7 @@ describe("modules/slack", () => {
       expect(result.text.includes("internal error")).toBe(true);
       expect(sectionTexts(result.blocks).length).toEqual(1);
       expect((result.attachments[0] as QuoteAttachment).color).toEqual(
-        QUOTE_COLOR,
+        QUOTE_ATTACHMENT_COLOR,
       );
       const stackSection = attachmentSectionTexts(result.attachments)[0][0];
       expect(stackSection.startsWith("```")).toBe(true);

--- a/src/main.ts
+++ b/src/main.ts
@@ -306,10 +306,11 @@ export const execCommentToAuthor = async (
   );
 
   const { slackWebhookUrl, iconUrl, botName } = allInputs;
-  const postSlackResult = await slackClient.postToSlack(
+  const postSlackResult = await postSlackPayload(
+    slackClient,
     slackWebhookUrl,
-    slackPayload.text,
-    { iconUrl, botName, blocks: slackPayload.blocks },
+    slackPayload,
+    { iconUrl, botName },
   );
 
   debug(

--- a/src/modules/slack.ts
+++ b/src/modules/slack.ts
@@ -7,7 +7,7 @@ export type SlackPostPayload = {
 // Slack section block text.text の上限は 3000 文字。安全余白を取って分割閾値を決める。
 export const SECTION_TEXT_LIMIT = 2800;
 export const CONTINUATION_SUFFIX = " (cont.)";
-const QUOTE_ATTACHMENT_COLOR = "#35373b";
+export const QUOTE_ATTACHMENT_COLOR = "#35373b";
 
 export const splitMrkdwnByLimit = (
   text: string,

--- a/src/modules/slack.ts
+++ b/src/modules/slack.ts
@@ -129,11 +129,7 @@ export const buildSlackCommentToAuthorMessage = (
   commentBody: string | null | undefined,
 ): SlackPostPayload => {
   const headline = `<@${prAuthorSlackUserId}> ${prLink} received a comment from ${commenter}.`;
-
-  return {
-    text: headline,
-    blocks: buildHeaderAndBodyBlocks(headline, commentBody),
-  };
+  return buildHeaderWithQuotedBody(headline, commentBody);
 };
 
 const openIssueLink =


### PR DESCRIPTION
## Summary

PR #370 (Block Kit 化) / #372 (attachment 化) / d9a6d41 (色値変更) で残った
2 件の不整合をまとめて修正する。

### 1. `buildSlackCommentToAuthorMessage` が未定義関数を参照

PR #372 で \`buildHeaderAndBodyBlocks\` → \`buildHeaderWithQuotedBody\` にリネーム + 役割変更 (本文を attachment へ移動) した際、\`buildSlackCommentToAuthorMessage\` だけ追従漏れだった。

- \`src/modules/slack.ts:135\` で存在しない \`buildHeaderAndBodyBlocks\` を呼ぶため \`tsc --noEmit\` がエラー、ランタイムでも \`ReferenceError\` になり「PR コメント → 作者通知」が常に失敗する状態 (issue_comment created の通知が壊れている)。
- 戻り値の \`attachments\` が抜けて \`SlackPostPayload\` 型と不整合。

→ 他 3 関数と同じく \`buildHeaderWithQuotedBody\` 経由に統一。本文がグレー縦線付き attachment として描画されるようになり、他通知と見た目も揃う。あわせて \`main.ts\` の \`execCommentToAuthor\` を \`postSlackPayload\` ヘルパに集約し、\`attachments\` が Slack へ正しく渡るようにした。

### 2. テストの \`QUOTE_COLOR\` 定数ドリフト

d9a6d41 で \`QUOTE_ATTACHMENT_COLOR\` を \`#cccccc\` → \`#35373b\` に変更した際、テスト側の \`QUOTE_COLOR\` 定数 (ハードコピー) が追従し損ねており、\`vitest run\` が常に red。

→ \`QUOTE_ATTACHMENT_COLOR\` を named export し、テストは import して参照するように統一。今回のようなドリフトの再発を防ぐ。

### 検証

- \`npx tsc --noEmit\` → エラーなし
- \`npx vitest run\` → 127 passed (1 todo)
- \`npx biome check .\` → 問題なし

## Test plan

- [ ] CI が green であること
- [ ] 既存の通知 (mention / review_submitted / error) の見た目が変わらないこと (本文が attachment 側にグレー縦線付きで表示される既存仕様を維持)
- [ ] PR Conversation タブで \`issue_comment.created\` を発火させた際、PR 作者宛て Slack 通知が届くこと (本 PR で初めて実通信可能になる)