### PR TITLE
Add RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -48,10 +48,10 @@ gh release create "$NEW_VERSION" \
 
 ### 3. major タグ `v2` を新リリースに追従させる
 
-`uses: abeyuya/actions-mention-to-slack@v2` の参照を新リリースに合わせるため、`v2` タグを force-update する。
+`uses: abeyuya/actions-mention-to-slack@v2` の参照を新リリースに合わせるため、`v2` タグを force-update する。直前に作った `$NEW_VERSION` タグの SHA から引くことで、ステップ 2-3 の間に release-latest-tag workflow が走っても整合する。
 
 ```bash
-RELEASE_SHA=$(git ls-remote origin refs/heads/release | awk '{print $1}')
+RELEASE_SHA=$(git ls-remote --tags origin "$NEW_VERSION" | awk '{print $1}')
 gh api -X PATCH \
   "/repos/$REPO/git/refs/tags/v2" \
   -f sha="$RELEASE_SHA" -F force=true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,9 +4,9 @@
 
 ## 前提
 
-- `master` への push をトリガに `.github/workflows/release-latest-tag.yml` が走り、`release` ブランチに master をマージ + `dist/` を build & commit + `latest` タグを force-update する。
+- `master` への push をトリガに `.github/workflows/release-latest-tag.yml` が走り、`release` ブランチに master をマージ + `dist/` を build & commit + `latest` タグを force-update する (build に差分があるときのみ commit / tag 更新)。
 - v2.X のセマンティックタグ / `v2` major タグ / GitHub Release の作成は手動。
-- `package.json` の `version` は更新しない (履歴上ずっと `"1.0.0"`)。
+- `package.json` の `version` は意図的に更新しない (バージョン管理は git タグ側に寄せている)。
 
 ## 手順
 
@@ -14,6 +14,7 @@
 
 ```bash
 NEW_VERSION=v2.13
+REPO=abeyuya/actions-mention-to-slack
 ```
 
 ### 1. 事前確認
@@ -24,7 +25,7 @@ gh auth status
 git fetch origin master release --tags
 git log -1 --oneline origin/release   # "update build N" になっているはず
 
-gh run list -R abeyuya/actions-mention-to-slack \
+gh run list -R "$REPO" \
   --workflow=release-latest-tag.yml --limit 3
 
 git ls-remote --tags origin "$NEW_VERSION"   # 何も返らないこと
@@ -36,7 +37,7 @@ git ls-remote --tags origin "$NEW_VERSION"   # 何も返らないこと
 
 ```bash
 gh release create "$NEW_VERSION" \
-  -R abeyuya/actions-mention-to-slack \
+  -R "$REPO" \
   --target release \
   --title "$NEW_VERSION" \
   --generate-notes
@@ -52,7 +53,7 @@ gh release create "$NEW_VERSION" \
 ```bash
 RELEASE_SHA=$(git ls-remote origin refs/heads/release | awk '{print $1}')
 gh api -X PATCH \
-  "/repos/abeyuya/actions-mention-to-slack/git/refs/tags/v2" \
+  "/repos/$REPO/git/refs/tags/v2" \
   -f sha="$RELEASE_SHA" -F force=true
 ```
 
@@ -61,7 +62,7 @@ gh api -X PATCH \
 ### 4. 確認
 
 ```bash
-gh release view "$NEW_VERSION" -R abeyuya/actions-mention-to-slack
+gh release view "$NEW_VERSION" -R "$REPO"
 git ls-remote --tags origin "$NEW_VERSION" v2
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,69 @@
+# Releasing
+
+`abeyuya/actions-mention-to-slack` の v2.X リリース手順。
+
+## 前提
+
+- `master` への push をトリガに `.github/workflows/release-latest-tag.yml` が走り、`release` ブランチに master をマージ + `dist/` を build & commit + `latest` タグを force-update する。
+- v2.X のセマンティックタグ / `v2` major タグ / GitHub Release の作成は手動。
+- `package.json` の `version` は更新しない (履歴上ずっと `"1.0.0"`)。
+
+## 手順
+
+新しい v2.X をリリースする。`NEW_VERSION` を差し替えて実行。
+
+```bash
+NEW_VERSION=v2.13
+```
+
+### 1. 事前確認
+
+```bash
+gh auth status
+
+git fetch origin master release --tags
+git log -1 --oneline origin/release   # "update build N" になっているはず
+
+gh run list -R abeyuya/actions-mention-to-slack \
+  --workflow=release-latest-tag.yml --limit 3
+
+git ls-remote --tags origin "$NEW_VERSION"   # 何も返らないこと
+```
+
+`release-latest-tag.yml` の最新実行が `success` でなければ、原因を確認してから進める。
+
+### 2. GitHub Release + タグ作成
+
+```bash
+gh release create "$NEW_VERSION" \
+  -R abeyuya/actions-mention-to-slack \
+  --target release \
+  --title "$NEW_VERSION" \
+  --generate-notes
+```
+
+- `--target release` で `origin/release` HEAD (`update build N` コミット) にタグが付く。
+- `--generate-notes` で前リリースからの Merged PR 一覧を自動生成。
+
+### 3. major タグ `v2` を新リリースに追従させる
+
+`uses: abeyuya/actions-mention-to-slack@v2` の参照を新リリースに合わせるため、`v2` タグを force-update する。
+
+```bash
+RELEASE_SHA=$(git ls-remote origin refs/heads/release | awk '{print $1}')
+gh api -X PATCH \
+  "/repos/abeyuya/actions-mention-to-slack/git/refs/tags/v2" \
+  -f sha="$RELEASE_SHA" -F force=true
+```
+
+`git push origin "$RELEASE_SHA:refs/tags/v2" --force` は protected tag の都合で 403 になることがあるため、API 経由を推奨。
+
+### 4. 確認
+
+```bash
+gh release view "$NEW_VERSION" -R abeyuya/actions-mention-to-slack
+git ls-remote --tags origin "$NEW_VERSION" v2
+```
+
+- `$NEW_VERSION` と `v2` が同じ SHA を指していれば成功。
+- `gh release view` でリリースノート本文と target commit を確認。


### PR DESCRIPTION
## Summary

- v2.13 リリース時に整理した手順を `RELEASING.md` として残す。
- 内容: `release-latest-tag.yml` の前提 / `gh release create --target release --generate-notes` でのタグ・Release 作成 / `gh api PATCH refs/tags/v2` での major タグ追従 / 確認手順。
- `package.json` の `version` は意図的に更新しない方針も明文化。

## Test plan

- [x] v2.13 リリースで実際に通った手順をそのまま記述したもの (https://github.com/abeyuya/actions-mention-to-slack/releases/tag/v2.13)
- [x] `v2` タグも `v2.13` と同じ commit (\`af0fe16\`) に追従済み
- [ ] 次回 v2.14 リリース時にこのドキュメントどおりで通るか検証