### PR TITLE
Align Slack post wording with official GitHub Slack integration (#355)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,27 @@ jobs:
 
 `type` is optional and defaults to `realtime-alert`, so existing workflows without this field keep working unchanged.
 
+Wording is aligned with the official GitHub Slack integration (`@github` bot). The leading `<@slack_id>` makes Slack actually notify the target user — that's the value-add of this action over the official integration.
+
+```
+<@U_USER>     sender_user   mentioned you in <url|[repo#71233] API docs ...>
+<@U_REVIEWER> requester     requested your review on <url|[repo#156133] Fix bug>
+<@U_OWNER>    reviewer_user approved <url|[repo#154822] Refactor>
+<@U_OWNER>    reviewer_user requested changes on <url|[repo#42] Update yml>
+<@U_OWNER>    reviewer_user commented on <url|[repo#42] Update yml>
+<@U_AUTHOR>   commenter     commented on <url|[repo#154973] Fix flaky test>
+```
+
+For mention / review-submitted / PR-comment notifications, the original GitHub body is appended below the headline as a grey-colored Slack attachment (markdown is converted to Slack mrkdwn).
+
 ### Scheduled reminder
 
 When invoked with `type: scheduled-reminder`, this action queries the open pull requests in the repository and posts a single aggregated Slack message listing each pending reviewer and the pull requests waiting on them. Users that appear in the mapping YAML are mentioned with `<@slack_id>` (or `<!subteam^id>` for teams); users not in the mapping are listed by their GitHub username.
 
 Each pull-request entry includes:
 
-- PR number and title (linked)
-- Time since the PR was opened (e.g. `3d`, `5h`)
+- PR number and title in `[<repo>#<n>] <title>` form (linked), plus PR author in parentheses — aligned with the official GitHub Slack integration
+- Time since the PR was opened (e.g. `3d old`, `5h old`)
 - Current approval state: `:white_check_mark: approved`, `:warning: changes requested`, or `:hourglass_flowing_sand: review required`
 - Labels attached to the PR (up to 5; the rest are summarized as `, +N more`)
 
@@ -87,13 +100,13 @@ The notification is delivered as a Slack Block Kit message with a plain-text fal
 Example rendering (text fallback):
 
 ```
-:eyes: Pending review reminders for `owner/repo`:
+:eyes: Reviews assigned to you on `owner/repo`
 
 <@U_ALICE>
-• <https://github.com/owner/repo/pull/123|#123 Fix login bug>
-_3d • :warning: changes requested • `bug`, `priority-high`_
-• <https://github.com/owner/repo/pull/130|#130 Refactor auth>
-_5h • :hourglass_flowing_sand: review required_
+• <https://github.com/owner/repo/pull/123|[repo#123] Fix login bug> (author_user)
+_3d old · :warning: changes requested · `bug`, `priority-high`_
+• <https://github.com/owner/repo/pull/130|[repo#130] Refactor auth> (another_user)
+_5h old · :hourglass_flowing_sand: review required_
 ```
 
 - Draft pull requests are excluded.

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -815,6 +815,7 @@ describe("src/main", () => {
           number: 42,
           title: "PR1",
           html_url: "https://example.com/pr/1",
+          user: { login: "author_user" },
           draft: false,
           created_at: "2026-05-14T12:00:00Z",
           labels: [{ name: "bug" }],
@@ -837,7 +838,8 @@ describe("src/main", () => {
       expect(call[0]).toEqual("dummy_url");
       expect(call[1]).toMatch("<@slack_user_1>");
       expect(call[1]).toMatch("`ghost`");
-      expect(call[1]).toMatch("<https://example.com/pr/1|#42 PR1>");
+      expect(call[1]).toMatch("<https://example.com/pr/1|[repo#42] PR1>");
+      expect(call[1]).toMatch("(author_user)");
       expect(call[2]).toMatchObject({
         blocks: expect.any(Array),
       });

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -126,10 +126,10 @@ describe("src/main", () => {
 
       const call = slackMock.postToSlack.mock.calls[0];
       expect(call[0]).toEqual("dummy_url");
-      expect(call[1].includes("<@slack_user_1>")).toEqual(true);
-      expect(call[1].includes("<pr_url|pr_title>")).toEqual(true);
-      expect(call[1].includes("by sender_github_username")).toEqual(true);
-      expect(call[1].includes("on abeyuya/github-actions-test")).toEqual(true);
+      expect(call[1]).toMatch("<@slack_user_1>");
+      expect(call[1]).toMatch(
+        "sender_github_username requested your review on <pr_url|[github-actions-test#1] pr_title>",
+      );
     });
 
     it("should not call postToSlack if requested_user is not listed in mapping", async () => {
@@ -207,10 +207,10 @@ describe("src/main", () => {
 
       const call = slackMock.postToSlack.mock.calls[0];
       expect(call[0]).toEqual("dummy_url");
-      expect(call[1].includes("<!subteam^slack_usergroup_1>")).toEqual(true);
-      expect(call[1].includes("<pr_url|pr_title>")).toEqual(true);
-      expect(call[1].includes("by sender_github_username")).toEqual(true);
-      expect(call[1].includes("on abeyuya/github-actions-test")).toEqual(true);
+      expect(call[1]).toMatch("<!subteam^slack_usergroup_1>");
+      expect(call[1]).toMatch(
+        "sender_github_username requested your review on <pr_url|[github-actions-test#1] pr_title>",
+      );
     });
   });
 
@@ -242,6 +242,11 @@ describe("src/main", () => {
           title: "pr_title",
           number: 1,
         },
+        repository: {
+          full_name: "abeyuya/github-actions-test",
+          name: "github-actions-test",
+          owner: { login: "abeyuya" },
+        },
         sender: {
           login: "sender_github_username",
           type: "sender_type",
@@ -260,11 +265,12 @@ describe("src/main", () => {
 
       const call = slackMock.postToSlack.mock.calls[0];
       expect(call[0]).toEqual("dummy_url");
-      expect(call[1].includes("<@slack_user_1>")).toEqual(true);
-      expect(call[1].includes("<review_comment_url|pr_title>")).toEqual(true);
-      expect(call[1].includes("by sender_github_username")).toEqual(true);
+      expect(call[1]).toMatch("<@slack_user_1>");
+      expect(call[1]).toMatch(
+        "sender_github_username mentioned you in <review_comment_url|[github-actions-test#1] pr_title>",
+      );
       // body should not be quoted with > any more, and should live in an attachment
-      expect(call[1].includes("> @github_user_1 LGTM!")).toEqual(false);
+      expect(call[1]).not.toMatch("> @github_user_1 LGTM!");
       expect(attachmentSectionTexts(call[2].attachments)).toEqual([
         ["@github_user_1 LGTM!"],
       ]);
@@ -284,6 +290,11 @@ describe("src/main", () => {
         pull_request: {
           title: "pr_title",
           number: 1,
+        },
+        repository: {
+          full_name: "abeyuya/github-actions-test",
+          name: "github-actions-test",
+          owner: { login: "abeyuya" },
         },
         sender: {
           login: "sender_github_username",
@@ -431,17 +442,17 @@ describe("src/main", () => {
       {
         state: "approved",
         body: "approve comment",
-        expectedPhrase: "has been approved by",
+        expectedPhrase: "abeyuya approved",
       },
       {
         state: "changes_requested",
         body: "please fix this",
-        expectedPhrase: "has changes requested by",
+        expectedPhrase: "abeyuya requested changes on",
       },
       {
         state: "commented",
         body: "just a comment",
-        expectedPhrase: "received a review comment from",
+        expectedPhrase: "abeyuya commented on",
       },
     ])("should send slack mention with $state wording", async ({
       state,
@@ -472,9 +483,8 @@ describe("src/main", () => {
       expect(call[1]).toMatch("<@pr_owner_slack_user>");
       expect(call[1]).toMatch(expectedPhrase);
       expect(call[1]).toMatch(
-        "<https://github.com/abeyuya/github-actions-test/pull/11#pullrequestreview-787479727|Update mention-to-slack.yml>",
+        "<https://github.com/abeyuya/github-actions-test/pull/11#pullrequestreview-787479727|[github-actions-test#11] Update mention-to-slack.yml>",
       );
-      expect(call[1]).toMatch("abeyuya");
       expect(attachmentSectionTexts(call[2].attachments)).toEqual([[body]]);
       expect(call[1]).not.toMatch(`> ${body}`);
     });
@@ -555,6 +565,7 @@ describe("src/main", () => {
         pull_request: { html_url: "pr_url" } as any,
         user: { login: overrides.authorLogin ?? "pr_author_github" },
         title: "pr_title",
+        number: 7,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -563,6 +574,11 @@ describe("src/main", () => {
         html_url: "comment_url",
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any,
+      repository: {
+        full_name: "owner/repo-name",
+        name: "repo-name",
+        owner: { login: "owner" },
+      },
       sender: {
         login: overrides.senderLogin ?? "commenter_github",
         type: overrides.senderType ?? "User",
@@ -586,8 +602,8 @@ describe("src/main", () => {
       const call = slackMock.postToSlack.mock.calls[0];
       expect(call[0]).toEqual("dummy_url");
       expect(call[1]).toMatch("<@pr_author_slack>");
-      expect(call[1]).toMatch("received a comment from commenter_github");
-      expect(call[1]).toMatch("<comment_url|pr_title>");
+      expect(call[1]).toMatch("commenter_github commented on");
+      expect(call[1]).toMatch("<comment_url|[repo-name#7] pr_title>");
       expect(attachmentSectionTexts(call[2].attachments)).toEqual([
         ["looks good"],
       ]);

--- a/__tests__/modules/github.test.ts
+++ b/__tests__/modules/github.test.ts
@@ -52,7 +52,12 @@ describe("modules/github", () => {
             body: "issue body",
             title: "issue title",
             html_url: "issue url",
-            number: 1,
+            number: 7,
+          },
+          repository: {
+            full_name: "owner/repo-name",
+            name: "repo-name",
+            owner: { login: "owner" },
           },
           sender: {
             login: "sender_github_username",
@@ -70,6 +75,8 @@ describe("modules/github", () => {
           title: "issue title",
           url: "issue url",
           senderName: "sender_github_username",
+          repoShortName: "repo-name",
+          number: 7,
         });
       });
 
@@ -82,6 +89,8 @@ describe("modules/github", () => {
           title: "issue title",
           url: "issue url",
           senderName: "sender_github_username",
+          repoShortName: "repo-name",
+          number: 7,
         });
       });
 
@@ -110,13 +119,18 @@ describe("modules/github", () => {
             body: "issue body",
             title: "issue title",
             html_url: "issue url",
-            number: 1,
+            number: 7,
           },
           comment: {
             id: 1,
             body: "comment body",
             title: "comment title",
             html_url: "comment url",
+          },
+          repository: {
+            full_name: "owner/repo-name",
+            name: "repo-name",
+            owner: { login: "owner" },
           },
           sender: {
             login: "sender_github_username",
@@ -134,6 +148,8 @@ describe("modules/github", () => {
           title: "issue title",
           url: "comment url",
           senderName: "sender_github_username",
+          repoShortName: "repo-name",
+          number: 7,
         });
       });
 
@@ -144,13 +160,18 @@ describe("modules/github", () => {
             body: "issue body",
             title: "issue title",
             html_url: "issue url",
-            number: 1,
+            number: 7,
           },
           comment: {
             id: 1,
             body: "> comment body \nhello",
             title: "comment title",
             html_url: "comment url",
+          },
+          repository: {
+            full_name: "owner/repo-name",
+            name: "repo-name",
+            owner: { login: "owner" },
           },
           sender: {
             login: "sender_github_username",
@@ -164,6 +185,8 @@ describe("modules/github", () => {
           title: "issue title",
           url: "comment url",
           senderName: "sender_github_username",
+          repoShortName: "repo-name",
+          number: 7,
         });
       });
 
@@ -176,6 +199,8 @@ describe("modules/github", () => {
           title: "issue title",
           url: "comment url",
           senderName: "sender_github_username",
+          repoShortName: "repo-name",
+          number: 7,
         });
       });
 
@@ -202,7 +227,12 @@ describe("modules/github", () => {
             body: "pr body",
             title: "pr title",
             html_url: "pr url",
-            number: 1,
+            number: 7,
+          },
+          repository: {
+            full_name: "owner/repo-name",
+            name: "repo-name",
+            owner: { login: "owner" },
           },
           sender: {
             login: "sender_github_username",
@@ -220,6 +250,8 @@ describe("modules/github", () => {
           title: "pr title",
           url: "pr url",
           senderName: "sender_github_username",
+          repoShortName: "repo-name",
+          number: 7,
         });
       });
 
@@ -232,6 +264,8 @@ describe("modules/github", () => {
           title: "pr title",
           url: "pr url",
           senderName: "sender_github_username",
+          repoShortName: "repo-name",
+          number: 7,
         });
       });
 
@@ -269,13 +303,18 @@ describe("modules/github", () => {
             body: "pr body",
             title: "pr title",
             html_url: "pr url",
-            number: 1,
+            number: 7,
           },
           comment: {
             id: 1,
             body: "comment body",
             title: "comment title",
             html_url: "comment url",
+          },
+          repository: {
+            full_name: "owner/repo-name",
+            name: "repo-name",
+            owner: { login: "owner" },
           },
           sender: {
             login: "sender_github_username",
@@ -293,6 +332,8 @@ describe("modules/github", () => {
           title: "pr title",
           url: "comment url",
           senderName: "sender_github_username",
+          repoShortName: "repo-name",
+          number: 7,
         });
       });
 
@@ -305,6 +346,8 @@ describe("modules/github", () => {
           title: "pr title",
           url: "comment url",
           senderName: "sender_github_username",
+          repoShortName: "repo-name",
+          number: 7,
         });
       });
 
@@ -329,12 +372,17 @@ describe("modules/github", () => {
             body: "pr body",
             title: "pr title",
             html_url: "pr url",
-            number: 1,
+            number: 7,
           },
           review: {
             body: "review body",
             title: "review title",
             html_url: "review url",
+          },
+          repository: {
+            full_name: "owner/repo-name",
+            name: "repo-name",
+            owner: { login: "owner" },
           },
           sender: {
             login: "sender_github_username",
@@ -352,6 +400,8 @@ describe("modules/github", () => {
           title: "pr title",
           url: "review url",
           senderName: "sender_github_username",
+          repoShortName: "repo-name",
+          number: 7,
         });
       });
 
@@ -371,6 +421,8 @@ describe("modules/github", () => {
         const result = pickupInfoFromGithubPayload(realPayload);
         expect(result.title).toEqual("test");
         expect(result.senderName).toEqual("abeyuya");
+        expect(result.repoShortName).toEqual("github-actions-test");
+        expect(result.number).toEqual(7);
       });
     });
 
@@ -380,6 +432,8 @@ describe("modules/github", () => {
         expect(result.title).toEqual("Update mention-to-slack.yml");
         expect(result.senderName).toEqual("abeyuya");
         expect(result.body).toEqual("approve comment");
+        expect(result.repoShortName).toEqual("github-actions-test");
+        expect(result.number).toEqual(11);
       });
     });
   });

--- a/__tests__/modules/reviewReminder.test.ts
+++ b/__tests__/modules/reviewReminder.test.ts
@@ -158,7 +158,7 @@ describe("reviewReminder", () => {
   describe("buildReviewReminderMessage", () => {
     it("returns null when entries are empty", () => {
       expect(
-        buildReviewReminderMessage([], "owner/repo", FIXED_NOW),
+        buildReviewReminderMessage([], "owner", "repo", FIXED_NOW),
       ).toBeNull();
     });
 
@@ -182,7 +182,8 @@ describe("reviewReminder", () => {
 
       const result = buildReviewReminderMessage(
         entries,
-        "owner/repo",
+        "owner",
+        "repo",
         FIXED_NOW,
       );
       assert(result, "expected a non-null payload");
@@ -227,7 +228,8 @@ describe("reviewReminder", () => {
 
       const result = buildReviewReminderMessage(
         entries,
-        "owner/repo",
+        "owner",
+        "repo",
         FIXED_NOW,
       );
       assert(result);
@@ -248,7 +250,8 @@ describe("reviewReminder", () => {
 
       const result = buildReviewReminderMessage(
         entries,
-        "owner/repo",
+        "owner",
+        "repo",
         FIXED_NOW,
       );
       assert(result);
@@ -284,7 +287,8 @@ describe("reviewReminder", () => {
 
       const result = buildReviewReminderMessage(
         entries,
-        "owner/repo",
+        "owner",
+        "repo",
         FIXED_NOW,
       );
       assert(result);
@@ -308,7 +312,8 @@ describe("reviewReminder", () => {
 
       const result = buildReviewReminderMessage(
         entries,
-        "owner/repo",
+        "owner",
+        "repo",
         FIXED_NOW,
       );
       assert(result);
@@ -332,7 +337,8 @@ describe("reviewReminder", () => {
 
       const result = buildReviewReminderMessage(
         entries,
-        "owner/repo",
+        "owner",
+        "repo",
         FIXED_NOW,
       );
       assert(result);
@@ -509,7 +515,8 @@ describe("reviewReminder", () => {
 
       const result = buildReviewReminderMessage(
         entries,
-        "owner/repo",
+        "owner",
+        "repo",
         FIXED_NOW,
       );
       assert(result);

--- a/__tests__/modules/reviewReminder.test.ts
+++ b/__tests__/modules/reviewReminder.test.ts
@@ -15,6 +15,7 @@ const makePr = (overrides: Record<string, unknown> = {}) => ({
   number: 1,
   title: "PR title",
   html_url: "https://example.com/pr/1",
+  user: { login: "author_user" },
   draft: false,
   created_at: "2026-05-14T12:00:00Z",
   labels: [],
@@ -27,6 +28,7 @@ const makeEntryPr = (overrides: Record<string, unknown> = {}) => ({
   number: 1,
   title: "PR title",
   url: "https://example.com/pr/1",
+  author: "author_user",
   createdAt: "2026-05-14T12:00:00Z",
   approvalState: "review_required" as const,
   labels: [],
@@ -188,8 +190,9 @@ describe("reviewReminder", () => {
 
       expect(text).toContain("owner/repo");
       expect(text).toContain("<@U_ALICE>");
-      expect(text).toContain("<https://example.com/pr/123|#123 Fix bug>");
-      expect(text).toContain("3d");
+      expect(text).toContain("<https://example.com/pr/123|[repo#123] Fix bug>");
+      expect(text).toContain("(author_user)");
+      expect(text).toContain("3d old");
       expect(text).toContain(":white_check_mark:");
       expect(text).toContain("approved");
       expect(text).toContain("`bug`");
@@ -199,7 +202,7 @@ describe("reviewReminder", () => {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: ":eyes: Pending review reminders for `owner/repo`:",
+          text: ":eyes: Reviews assigned to you on `owner/repo`",
         },
       });
       expect(blocks[1]).toEqual({ type: "divider" });
@@ -229,7 +232,9 @@ describe("reviewReminder", () => {
       );
       assert(result);
       expect(result.text).toContain("<!subteam^S_TEAM>");
-      expect(result.text).toContain("<https://example.com/pr/2|#2 Feature X>");
+      expect(result.text).toContain(
+        "<https://example.com/pr/2|[repo#2] Feature X>",
+      );
     });
 
     it("renders unmapped user with backticked github name", () => {
@@ -418,6 +423,7 @@ describe("reviewReminder", () => {
       assert(pr1);
       expect(pr1.title).toBe("PR1");
       expect(pr1.url).toBe("https://example.com/pr/1");
+      expect(pr1.author).toBe("author_user");
       expect(pr1.createdAt).toBe("2026-05-14T12:00:00Z");
       // alice / bob が pending として残るため、x の APPROVED だけでは approved にならない
       expect(pr1.approvalState).toBe("review_required");

--- a/__tests__/modules/slack.test.ts
+++ b/__tests__/modules/slack.test.ts
@@ -2,9 +2,12 @@ import {
   buildSlackCommentToAuthorMessage,
   buildSlackErrorMessage,
   buildSlackPostMessage,
+  buildSlackReviewRequestedMessage,
   buildSlackReviewSubmittedMessage,
   CONTINUATION_SUFFIX,
   convertGithubMarkdownToSlackMrkdwn,
+  formatIssueRef,
+  formatIssueRefLink,
   QUOTE_ATTACHMENT_COLOR,
   SECTION_TEXT_LIMIT,
   splitMrkdwnByLimit,
@@ -16,18 +19,36 @@ import {
 } from "../fixture/slackBlocks.js";
 
 describe("modules/slack", () => {
+  describe("formatIssueRef", () => {
+    it("renders `[repo#number] title` in the official GitHub Slack style", () => {
+      expect(formatIssueRef("monorepo", 71233, "API docs")).toEqual(
+        "[monorepo#71233] API docs",
+      );
+    });
+  });
+
+  describe("formatIssueRefLink", () => {
+    it("wraps the issue ref in a Slack mrkdwn link", () => {
+      expect(
+        formatIssueRefLink("https://example.com/pr/42", "repo", 42, "Fix bug"),
+      ).toEqual("<https://example.com/pr/42|[repo#42] Fix bug>");
+    });
+  });
+
   describe("buildSlackPostMessage", () => {
     it("should keep only the headline in text/blocks and put the body in a grey-colored attachment", () => {
       const result = buildSlackPostMessage(
         ["slackUser1"],
+        "repo",
+        42,
         "title",
-        "link",
+        "https://example.com/c",
         "message",
         "sender_github_username",
       );
 
       const expectedHeadline =
-        "<@slackUser1> has been mentioned at <link|title> by sender_github_username";
+        "<@slackUser1> sender_github_username mentioned you in <https://example.com/c|[repo#42] title>";
       expect(result.text).toEqual(expectedHeadline);
       expect(sectionTexts(result.blocks)).toEqual([expectedHeadline]);
 
@@ -41,8 +62,10 @@ describe("modules/slack", () => {
     it("should route github body through Slack mrkdwn conversion", () => {
       const result = buildSlackPostMessage(
         ["slackUser1"],
+        "repo",
+        42,
         "title",
-        "link",
+        "https://example.com/c",
         "## heading\n\nbody",
         "sender_github_username",
       );
@@ -52,17 +75,19 @@ describe("modules/slack", () => {
       ]);
     });
 
-    it("should use 'have' for multiple mentions and join them with spaces", () => {
+    it("should join multiple mentions with spaces and keep the verb invariant", () => {
       const result = buildSlackPostMessage(
         ["slackUser1", "slackUser2"],
+        "repo",
+        42,
         "title",
-        "link",
+        "https://example.com/c",
         "body",
         "sender_github_username",
       );
 
       expect(result.text).toEqual(
-        "<@slackUser1> <@slackUser2> have been mentioned at <link|title> by sender_github_username",
+        "<@slackUser1> <@slackUser2> sender_github_username mentioned you in <https://example.com/c|[repo#42] title>",
       );
     });
 
@@ -70,8 +95,10 @@ describe("modules/slack", () => {
       const body = "a".repeat(8000);
       const result = buildSlackPostMessage(
         ["slackUser1"],
+        "repo",
+        42,
         "title",
-        "link",
+        "https://example.com/c",
         body,
         "sender_github_username",
       );
@@ -86,8 +113,10 @@ describe("modules/slack", () => {
     it("should omit attachments when github body is empty", () => {
       const result = buildSlackPostMessage(
         ["slackUser1"],
+        "repo",
+        42,
         "title",
-        "link",
+        "https://example.com/c",
         "",
         "sender_github_username",
       );
@@ -97,22 +126,44 @@ describe("modules/slack", () => {
     });
   });
 
+  describe("buildSlackReviewRequestedMessage", () => {
+    it("composes the headline in official GitHub Slack style without quoting PR body", () => {
+      const result = buildSlackReviewRequestedMessage(
+        "<@U_REVIEWER>",
+        "https://example.com/pr/42",
+        "repo",
+        42,
+        "Fix bug",
+        "requester_user",
+      );
+
+      const expectedHeadline =
+        "<@U_REVIEWER> requester_user requested your review on <https://example.com/pr/42|[repo#42] Fix bug>";
+      expect(result.text).toEqual(expectedHeadline);
+      expect(sectionTexts(result.blocks)).toEqual([expectedHeadline]);
+      expect(result.attachments).toEqual([]);
+    });
+  });
+
   describe("buildSlackReviewSubmittedMessage", () => {
     it.each([
-      ["approved", "has been approved by reviewer_user"],
-      ["changes_requested", "has changes requested by reviewer_user"],
-      ["commented", "received a review comment from reviewer_user"],
-      [undefined, "received a review comment from reviewer_user"],
-    ] as const)("should compose headline for review state '%s'", (state, tail) => {
+      ["approved", "reviewer_user approved"],
+      ["changes_requested", "reviewer_user requested changes on"],
+      ["commented", "reviewer_user commented on"],
+      [undefined, "reviewer_user commented on"],
+    ] as const)("should compose headline for review state '%s'", (state, verb) => {
       const result = buildSlackReviewSubmittedMessage(
         "U_OWNER",
-        "<https://example.com/pr/1|#42 PR1>",
+        "https://example.com/pr/42",
+        "repo",
+        42,
+        "PR1",
         "reviewer_user",
         state,
         "review body",
       );
 
-      const expectedHeadline = `<@U_OWNER> <https://example.com/pr/1|#42 PR1> ${tail}.`;
+      const expectedHeadline = `<@U_OWNER> ${verb} <https://example.com/pr/42|[repo#42] PR1>`;
       expect(result.text).toEqual(expectedHeadline);
       expect(sectionTexts(result.blocks)).toEqual([expectedHeadline]);
       expect(attachmentSectionTexts(result.attachments)).toEqual([
@@ -123,7 +174,10 @@ describe("modules/slack", () => {
     it("should omit attachments when review body is empty or null", () => {
       const result = buildSlackReviewSubmittedMessage(
         "U_OWNER",
-        "<link|title>",
+        "https://example.com/pr/42",
+        "repo",
+        42,
+        "PR1",
         "reviewer_user",
         "approved",
         null,
@@ -137,13 +191,16 @@ describe("modules/slack", () => {
     it("should keep only the headline in text/blocks and put the body in a grey-colored attachment", () => {
       const result = buildSlackCommentToAuthorMessage(
         "U_AUTHOR",
-        "<https://example.com/pr/1|#42 PR1>",
+        "https://example.com/pr/42",
+        "repo",
+        42,
+        "PR1",
         "commenter_user",
         "looks good",
       );
 
       const expectedHeadline =
-        "<@U_AUTHOR> <https://example.com/pr/1|#42 PR1> received a comment from commenter_user.";
+        "<@U_AUTHOR> commenter_user commented on <https://example.com/pr/42|[repo#42] PR1>";
       expect(result.text).toEqual(expectedHeadline);
       expect(sectionTexts(result.blocks)).toEqual([expectedHeadline]);
 
@@ -159,7 +216,10 @@ describe("modules/slack", () => {
     it("should omit attachments when the comment body is empty or null", () => {
       const result = buildSlackCommentToAuthorMessage(
         "U_AUTHOR",
-        "<link|title>",
+        "https://example.com/pr/42",
+        "repo",
+        42,
+        "PR1",
         "commenter_user",
         null,
       );

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import {
   buildSlackCommentToAuthorMessage,
   buildSlackErrorMessage,
   buildSlackPostMessage,
+  buildSlackReviewRequestedMessage,
   buildSlackReviewSubmittedMessage,
   type SlackPostPayload,
   SlackRepositoryImpl,
@@ -109,16 +110,27 @@ export const execPrReviewRequestedMention = async (
     return;
   }
 
-  const title = payload.pull_request?.title;
-  const url = payload.pull_request?.html_url;
-  const repoName = payload.repository?.full_name;
-  const requestUsername = payload.sender?.login;
+  const title = payload.pull_request?.title || "";
+  const url = payload.pull_request?.html_url || "";
+  const repoShortName = payload.repository?.name || "";
+  const prNumber = payload.pull_request?.number || 0;
+  const requestUsername = payload.sender?.login || "";
 
   const slackMention = getSlackMention(slackUserIds[0], slackUserGroupIds[0]);
-  const message = `${slackMention} has been requested to review <${url}|${title}> by ${requestUsername} on ${repoName}.`;
+  const slackPayload = buildSlackReviewRequestedMessage(
+    slackMention,
+    url,
+    repoShortName,
+    prNumber,
+    title,
+    requestUsername,
+  );
   const { slackWebhookUrl, iconUrl, botName } = allInputs;
 
-  await slackClient.postToSlack(slackWebhookUrl, message, { iconUrl, botName });
+  await postSlackPayload(slackClient, slackWebhookUrl, slackPayload, {
+    iconUrl,
+    botName,
+  });
 };
 
 export const execNormalMention = async (
@@ -156,6 +168,8 @@ export const execNormalMention = async (
 
   const slackPayload = buildSlackPostMessage(
     slackIdsWithoutIgnore,
+    info.repoShortName,
+    info.number,
     info.title,
     info.url,
     info.body,
@@ -212,10 +226,12 @@ export const execReviewSubmittedMention = async (
     return null;
   }
 
-  const prLink = `<${info.url}|${info.title}>`;
   const slackPayload = buildSlackReviewSubmittedMessage(
     prOwnerSlackUserId,
-    prLink,
+    info.url,
+    info.repoShortName,
+    info.number,
+    info.title,
     reviewer,
     reviewState,
     info.body,
@@ -296,11 +312,13 @@ export const execCommentToAuthor = async (
 
   const info = pickupInfoFromGithubPayload(payload);
   const prAuthorSlackUserId = slackIds[0];
-  const prLink = `<${info.url}|${info.title}>`;
 
   const slackPayload = buildSlackCommentToAuthorMessage(
     prAuthorSlackUserId,
-    prLink,
+    info.url,
+    info.repoShortName,
+    info.number,
+    info.title,
     commenter ?? "",
     info.body,
   );

--- a/src/main.ts
+++ b/src/main.ts
@@ -110,20 +110,15 @@ export const execPrReviewRequestedMention = async (
     return;
   }
 
-  const title = payload.pull_request?.title || "";
-  const url = payload.pull_request?.html_url || "";
-  const repoShortName = payload.repository?.name || "";
-  const prNumber = payload.pull_request?.number || 0;
-  const requestUsername = payload.sender?.login || "";
-
+  const info = pickupInfoFromGithubPayload(payload);
   const slackMention = getSlackMention(slackUserIds[0], slackUserGroupIds[0]);
   const slackPayload = buildSlackReviewRequestedMessage(
     slackMention,
-    url,
-    repoShortName,
-    prNumber,
-    title,
-    requestUsername,
+    info.url,
+    info.repoShortName,
+    info.number,
+    info.title,
+    info.senderName,
   );
   const { slackWebhookUrl, iconUrl, botName } = allInputs;
 
@@ -355,7 +350,7 @@ export const execReviewReminder = async (
     slackId: mapping[r.githubName],
   }));
 
-  const payload = buildReviewReminderMessage(entries, `${owner}/${repo}`);
+  const payload = buildReviewReminderMessage(entries, owner, repo);
   if (!payload) {
     debug("finish execReviewReminder because no pending reviews");
     return;

--- a/src/modules/github.ts
+++ b/src/modules/github.ts
@@ -50,21 +50,32 @@ export const needToSendReviewSubmittedMention = (
   return Boolean(payload.review);
 };
 
-export const pickupInfoFromGithubPayload = (
-  payload: Partial<typeof context.payload>,
-): {
+export type GithubPayloadInfo = {
   body: string | null;
   title: string;
   url: string;
   senderName: string;
-} => {
+  repoShortName: string;
+  number: number;
+};
+
+export const pickupInfoFromGithubPayload = (
+  payload: Partial<typeof context.payload>,
+): GithubPayloadInfo => {
+  const repoShortName = payload.repository?.name || "";
+  const senderName = payload.sender?.login || "";
+
   if (payload.issue) {
+    const number = payload.issue.number || 0;
+
     if (payload.comment) {
       return {
         body: payload.comment.body,
         title: payload.issue.title,
         url: payload.comment.html_url,
-        senderName: payload.sender?.login || "",
+        senderName,
+        repoShortName,
+        number,
       };
     }
 
@@ -72,17 +83,23 @@ export const pickupInfoFromGithubPayload = (
       body: payload.issue.body || "",
       title: payload.issue.title,
       url: payload.issue.html_url || "",
-      senderName: payload.sender?.login || "",
+      senderName,
+      repoShortName,
+      number,
     };
   }
 
   if (payload.pull_request) {
+    const number = payload.pull_request.number || 0;
+
     if (payload.review) {
       return {
         body: payload.review.body,
         title: payload.pull_request?.title || "",
         url: payload.review.html_url,
-        senderName: payload.sender?.login || "",
+        senderName,
+        repoShortName,
+        number,
       };
     }
 
@@ -91,7 +108,9 @@ export const pickupInfoFromGithubPayload = (
         body: payload.comment.body,
         title: payload.pull_request.title,
         url: payload.comment.html_url,
-        senderName: payload.sender?.login || "",
+        senderName,
+        repoShortName,
+        number,
       };
     }
 
@@ -99,7 +118,9 @@ export const pickupInfoFromGithubPayload = (
       body: payload.pull_request.body || "",
       title: payload.pull_request.title,
       url: payload.pull_request.html_url || "",
-      senderName: payload.sender?.login || "",
+      senderName,
+      repoShortName,
+      number,
     };
   }
 

--- a/src/modules/github.ts
+++ b/src/modules/github.ts
@@ -64,64 +64,62 @@ export const pickupInfoFromGithubPayload = (
 ): GithubPayloadInfo => {
   const repoShortName = payload.repository?.name || "";
   const senderName = payload.sender?.login || "";
+  const make = (
+    body: string | null,
+    title: string,
+    url: string,
+    number: number,
+  ): GithubPayloadInfo => ({
+    body,
+    title,
+    url,
+    senderName,
+    repoShortName,
+    number,
+  });
 
   if (payload.issue) {
     const number = payload.issue.number || 0;
-
     if (payload.comment) {
-      return {
-        body: payload.comment.body,
-        title: payload.issue.title,
-        url: payload.comment.html_url,
-        senderName,
-        repoShortName,
+      return make(
+        payload.comment.body,
+        payload.issue.title,
+        payload.comment.html_url,
         number,
-      };
+      );
     }
-
-    return {
-      body: payload.issue.body || "",
-      title: payload.issue.title,
-      url: payload.issue.html_url || "",
-      senderName,
-      repoShortName,
+    return make(
+      payload.issue.body || "",
+      payload.issue.title,
+      payload.issue.html_url || "",
       number,
-    };
+    );
   }
 
   if (payload.pull_request) {
     const number = payload.pull_request.number || 0;
-
     if (payload.review) {
-      return {
-        body: payload.review.body,
-        title: payload.pull_request?.title || "",
-        url: payload.review.html_url,
-        senderName,
-        repoShortName,
+      return make(
+        payload.review.body,
+        payload.pull_request.title || "",
+        payload.review.html_url,
         number,
-      };
+      );
     }
-
     if (payload.comment) {
-      return {
-        body: payload.comment.body,
-        title: payload.pull_request.title,
-        url: payload.comment.html_url,
-        senderName,
-        repoShortName,
+      return make(
+        payload.comment.body,
+        payload.pull_request.title,
+        payload.comment.html_url,
         number,
-      };
+      );
     }
-
-    return {
-      body: payload.pull_request.body || "",
-      title: payload.pull_request.title,
-      url: payload.pull_request.html_url || "",
-      senderName,
-      repoShortName,
+    return make(
+      payload.pull_request.body || "",
+      payload.pull_request.title,
+      payload.pull_request.html_url || "",
       number,
-    };
+    );
   }
 
   throw new Error(

--- a/src/modules/reviewReminder.ts
+++ b/src/modules/reviewReminder.ts
@@ -3,6 +3,7 @@ import type { getOctokit } from "@actions/github";
 import {
   buildSection,
   CONTINUATION_SUFFIX,
+  formatIssueRef,
   SECTION_TEXT_LIMIT,
   type SlackPostPayload,
 } from "./slack.js";
@@ -16,6 +17,7 @@ export type ReminderPr = {
   number: number;
   title: string;
   url: string;
+  author: string;
   createdAt: string;
   approvalState: ApprovalState;
   labels: string[];
@@ -114,14 +116,20 @@ const APPROVAL_DISPLAY: Record<
   },
 };
 
-const buildPrLine = (pr: ReminderPr, now: Date): string => {
+const buildPrLine = (
+  pr: ReminderPr,
+  repoShortName: string,
+  now: Date,
+): string => {
   const age = formatRelativeAge(new Date(pr.createdAt), now);
   const approval = APPROVAL_DISPLAY[pr.approvalState];
   const labelText = formatLabels(pr.labels);
-  const metaParts = [age, `${approval.emoji} ${approval.label}`];
+  const refLink = `<${pr.url}|${formatIssueRef(repoShortName, pr.number, pr.title)}>`;
+  const authorSuffix = pr.author ? ` (${pr.author})` : "";
+  const metaParts = [`${age} old`, `${approval.emoji} ${approval.label}`];
   if (labelText) metaParts.push(labelText);
-  const meta = `_${metaParts.join(" • ")}_`;
-  return `• <${pr.url}|#${pr.number} ${pr.title}>\n${meta}`;
+  const meta = `_${metaParts.join(" · ")}_`;
+  return `• ${refLink}${authorSuffix}\n${meta}`;
 };
 
 const splitSectionByLimit = (header: string, prLines: string[]): string[] => {
@@ -207,6 +215,7 @@ export const fetchOpenReviewRequests = async (
       number: pr.number,
       title: pr.title,
       url: pr.html_url,
+      author: pr.user?.login ?? "",
       createdAt: pr.created_at,
       approvalState,
       labels: (pr.labels ?? []).flatMap((l: unknown) => {
@@ -253,14 +262,16 @@ export const buildReviewReminderMessage = (
 ): ReminderSlackPayload | null => {
   if (entries.length === 0) return null;
 
-  const headerText = `:eyes: Pending review reminders for \`${repoFullName}\`:`;
+  const headerText = `:eyes: Reviews assigned to you on \`${repoFullName}\``;
+  // owner/repo の短い側を `[repo#n]` のリンクテキストに使う (純正もリポジトリ短縮名)
+  const repoShortName = repoFullName.split("/").pop() || repoFullName;
 
   const entryBlockTexts: string[] = [];
   const entryTextSections: string[] = [];
 
   for (const entry of entries) {
     const header = buildEntryHeader(entry);
-    const prLines = entry.prs.map((pr) => buildPrLine(pr, now));
+    const prLines = entry.prs.map((pr) => buildPrLine(pr, repoShortName, now));
     entryTextSections.push([header, ...prLines].join("\n"));
     entryBlockTexts.push(...splitSectionByLimit(header, prLines));
   }

--- a/src/modules/reviewReminder.ts
+++ b/src/modules/reviewReminder.ts
@@ -3,7 +3,7 @@ import type { getOctokit } from "@actions/github";
 import {
   buildSection,
   CONTINUATION_SUFFIX,
-  formatIssueRef,
+  formatIssueRefLink,
   SECTION_TEXT_LIMIT,
   type SlackPostPayload,
 } from "./slack.js";
@@ -124,7 +124,12 @@ const buildPrLine = (
   const age = formatRelativeAge(new Date(pr.createdAt), now);
   const approval = APPROVAL_DISPLAY[pr.approvalState];
   const labelText = formatLabels(pr.labels);
-  const refLink = `<${pr.url}|${formatIssueRef(repoShortName, pr.number, pr.title)}>`;
+  const refLink = formatIssueRefLink(
+    pr.url,
+    repoShortName,
+    pr.number,
+    pr.title,
+  );
   const authorSuffix = pr.author ? ` (${pr.author})` : "";
   const metaParts = [`${age} old`, `${approval.emoji} ${approval.label}`];
   if (labelText) metaParts.push(labelText);
@@ -257,21 +262,20 @@ const buildEntryHeader = (entry: ReminderEntry): string => {
 
 export const buildReviewReminderMessage = (
   entries: ReminderEntry[],
-  repoFullName: string,
+  owner: string,
+  repo: string,
   now: Date = new Date(),
 ): ReminderSlackPayload | null => {
   if (entries.length === 0) return null;
 
-  const headerText = `:eyes: Reviews assigned to you on \`${repoFullName}\``;
-  // owner/repo の短い側を `[repo#n]` のリンクテキストに使う (純正もリポジトリ短縮名)
-  const repoShortName = repoFullName.split("/").pop() || repoFullName;
+  const headerText = `:eyes: Reviews assigned to you on \`${owner}/${repo}\``;
 
   const entryBlockTexts: string[] = [];
   const entryTextSections: string[] = [];
 
   for (const entry of entries) {
     const header = buildEntryHeader(entry);
-    const prLines = entry.prs.map((pr) => buildPrLine(pr, repoShortName, now));
+    const prLines = entry.prs.map((pr) => buildPrLine(pr, repo, now));
     entryTextSections.push([header, ...prLines].join("\n"));
     entryBlockTexts.push(...splitSectionByLimit(header, prLines));
   }

--- a/src/modules/slack.ts
+++ b/src/modules/slack.ts
@@ -85,6 +85,20 @@ export const convertGithubMarkdownToSlackMrkdwn = (
   body: string | null | undefined,
 ): string => (body ? slackifyMarkdown(body).trimEnd() : "");
 
+// 純正 GitHub Slack 連携の表記に揃える: `[<repo>#<number>] <title>`
+export const formatIssueRef = (
+  repoShortName: string,
+  number: number,
+  title: string,
+): string => `[${repoShortName}#${number}] ${title}`;
+
+export const formatIssueRefLink = (
+  url: string,
+  repoShortName: string,
+  number: number,
+  title: string,
+): string => `<${url}|${formatIssueRef(repoShortName, number, title)}>`;
+
 const buildHeaderWithQuotedBody = (
   headline: string,
   body: string | null | undefined,
@@ -99,33 +113,61 @@ const buildHeaderWithQuotedBody = (
 
 export const buildSlackPostMessage = (
   slackIdsForMention: string[],
+  repoShortName: string,
+  issueNumber: number,
   issueTitle: string,
   commentLink: string,
   githubBody: string,
   senderName: string,
 ): SlackPostPayload => {
   const mentionBlock = slackIdsForMention.map((id) => `<@${id}>`).join(" ");
-  const verb = slackIdsForMention.length === 1 ? "has" : "have";
-  const headline = `${mentionBlock} ${verb} been mentioned at <${commentLink}|${issueTitle}> by ${senderName}`;
+  const refLink = formatIssueRefLink(
+    commentLink,
+    repoShortName,
+    issueNumber,
+    issueTitle,
+  );
+  const headline = `${mentionBlock} ${senderName} mentioned you in ${refLink}`;
   return buildHeaderWithQuotedBody(headline, githubBody);
+};
+
+export const buildSlackReviewRequestedMessage = (
+  reviewerSlackMention: string,
+  url: string,
+  repoShortName: string,
+  prNumber: number,
+  prTitle: string,
+  requester: string,
+): SlackPostPayload => {
+  const refLink = formatIssueRefLink(url, repoShortName, prNumber, prTitle);
+  const headline = `${reviewerSlackMention} ${requester} requested your review on ${refLink}`;
+  return {
+    text: headline,
+    blocks: [buildSection(headline)],
+    attachments: [],
+  };
 };
 
 export const buildSlackReviewSubmittedMessage = (
   prOwnerSlackUserId: string,
-  prLink: string,
+  url: string,
+  repoShortName: string,
+  prNumber: number,
+  prTitle: string,
   reviewer: string,
   reviewState: string | undefined,
   reviewBody: string | null | undefined,
 ): SlackPostPayload => {
   const userMention = `<@${prOwnerSlackUserId}>`;
+  const refLink = formatIssueRefLink(url, repoShortName, prNumber, prTitle);
   const headline = (() => {
     switch (reviewState) {
       case "approved":
-        return `${userMention} ${prLink} has been approved by ${reviewer}.`;
+        return `${userMention} ${reviewer} approved ${refLink}`;
       case "changes_requested":
-        return `${userMention} ${prLink} has changes requested by ${reviewer}.`;
+        return `${userMention} ${reviewer} requested changes on ${refLink}`;
       default:
-        return `${userMention} ${prLink} received a review comment from ${reviewer}.`;
+        return `${userMention} ${reviewer} commented on ${refLink}`;
     }
   })();
   return buildHeaderWithQuotedBody(headline, reviewBody);
@@ -133,11 +175,15 @@ export const buildSlackReviewSubmittedMessage = (
 
 export const buildSlackCommentToAuthorMessage = (
   prAuthorSlackUserId: string,
-  prLink: string,
+  url: string,
+  repoShortName: string,
+  prNumber: number,
+  prTitle: string,
   commenter: string,
   commentBody: string | null | undefined,
 ): SlackPostPayload => {
-  const headline = `<@${prAuthorSlackUserId}> ${prLink} received a comment from ${commenter}.`;
+  const refLink = formatIssueRefLink(url, repoShortName, prNumber, prTitle);
+  const headline = `<@${prAuthorSlackUserId}> ${commenter} commented on ${refLink}`;
   return buildHeaderWithQuotedBody(headline, commentBody);
 };
 


### PR DESCRIPTION
## Summary

Closes #355.

純正 GitHub Slack 連携 (`@github` Bot) のフォーマットに揃え、本 action 利用者の Slack 上のメンタルモデルを統一する。文面だけでなくリンクテキストや絵文字構成も合わせ、純正と並べたときに違和感のない見た目にする。

通知ターゲットを Slack 上で実際にメンションする `<@SlackUserId>` 部分は、本 action のコア機能なので headline 先頭に残している (純正には無い)。

## 文言比較表 (現状 → 純正 → 本 PR)

| イベント | 現状 | 純正 | 本 PR |
|---|---|---|---|
| Mention | `<@U> has been mentioned at <url\|title> by sender` | `@sender mentioned you in [repo#n] title` | `<@U> sender mentioned you in <url\|[repo#n] title>` |
| Review requested | `<@U> has been requested to review <url\|title> by sender on owner/repo.` | `@sender requested your review on [repo#n] title` | `<@U> sender requested your review on <url\|[repo#n] title>` |
| Approved | `<@U> <url\|title> has been approved by reviewer.` | `reviewer approved [repo#n] title` | `<@U> reviewer approved <url\|[repo#n] title>` |
| Changes requested | `<@U> <url\|title> has changes requested by reviewer.` | `reviewer requested changes on [repo#n] title` | `<@U> reviewer requested changes on <url\|[repo#n] title>` |
| Review commented | `<@U> <url\|title> received a review comment from reviewer.` | `reviewer commented on [repo#n] title` | `<@U> reviewer commented on <url\|[repo#n] title>` |
| Comment to author | `<@U> <url\|title> received a comment from commenter.` | `commenter commented on [repo#n] title` | `<@U> commenter commented on <url\|[repo#n] title>` |
| Reminder header | `:eyes: Pending review reminders for \`owner/repo\`:` | `Reviews assigned to you on owner/repo` | `:eyes: Reviews assigned to you on \`owner/repo\`` |
| Reminder PR 行 | `• <url\|#n title>` / `_age • emoji label • labels_` | `[repo#n] title (author)` / `age old · Waiting on @...` | `• <url\|[repo#n] title> (author)` / `_age old · emoji label · labels_` |

## 主な変更

- `src/modules/slack.ts`: 共通ヘルパ `formatIssueRef` / `formatIssueRefLink` を追加。`buildSlackPostMessage` / `buildSlackReviewSubmittedMessage` / `buildSlackCommentToAuthorMessage` のシグネチャを `[<repo>#<number>] <title>` リンク用に拡張し、文言を純正に揃えた。新規 `buildSlackReviewRequestedMessage` で review_requested の文字列組み立てを関数化。
- `src/modules/github.ts`: `pickupInfoFromGithubPayload` の返り値に `repoShortName` と `number` を追加。
- `src/modules/reviewReminder.ts`: ヘッダを `Reviews assigned to you on \`owner/repo\`` に変更。PR 行を `[<repo>#<n>] <title> (<author>)` 形式 + `age old · approval · labels` の中黒区切りに変更。`ReminderPr` に `author` を追加し、`fetchOpenReviewRequests` で `pr.user.login` を保持。
- `src/main.ts`: 4 つの exec ハンドラを `pickupInfoFromGithubPayload` 経由に統一し、新シグネチャに合わせて呼び出しを更新。`execPrReviewRequestedMention` の生文字列組み立てを削除。
- `README.md`: 純正寄せの realtime alert 出力例を新規追加。scheduled-reminder の例を新文言に更新。
- 既存テストの assertion を新文言に更新 (snapshot test は導入していない)。

## 設計判断 (issue / 質問の回答)

- リンクテキストの範囲: `<url|[repo#number] title>` の全体を 1 リンクに (純正と同じ見た目)。
- `<@SlackUserId>` メンションは見出し先頭に維持 (本 action のコア機能)。
- Reminder の付加情報 (approval state 絵文字 / labels) は純正には無いが価値があるので折衷で残す。`stale` 表記は GitHub 側ロジックで決まり再現困難なので省略。
- Issue/PR 本文の引用 attachment は現状維持。

## Test plan

- [x] `npx vitest run` — 134 passed
- [x] `npx tsc --noEmit` — 型エラーなし
- [x] `npx biome check .` — lint / format エラーなし
- [ ] レビュー後にスクショで Slack 上の見た目を確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01NR2VxEJsHbqVtf3tsYtxG2)_