### PR TITLE
feat(scheduled-reminder): add ignored-terms title keyword filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This action has two modes, controlled by the `type` input (aligned with GitHub's
 | run-id             | No       | Null                         | Used for the link in the error message when an error occurs.                                                                                             |
 | type               | No       | realtime-alert               | Mode of operation. `realtime-alert` (default) sends event-driven mention/review notifications. `scheduled-reminder` posts an aggregated reminder of open pull requests with pending review requests. Leaving it empty is the same as `realtime-alert`. |
 | notify-bot-comment | No       | false                        | If `"true"`, the PR-author-on-comment notification (see Feature) also fires when the comment sender is a bot (`payload.sender.type === "Bot"`). Defaults to `"false"`, which mirrors GitHub's official "Someone comments on your PR" reminder by skipping bot comments. |
+| ignored-terms      | No       | Null                         | Comma-separated keywords used only in `scheduled-reminder` mode. Pull requests whose title contains any of these terms (case-insensitive substring match) are excluded from the reminder, mirroring GitHub Scheduled Reminders' "Ignored terms". |
 
 ## Example usage
 
@@ -110,6 +111,7 @@ _5h old · :hourglass_flowing_sand: review required_
 ```
 
 - Draft pull requests are excluded.
+- Pull requests whose title matches any keyword in `ignored-terms` (case-insensitive substring match) are excluded, mirroring GitHub Scheduled Reminders' "Ignored terms".
 - If there are no pending review requests, nothing is posted.
 - Approval state is fetched via the `pulls.listReviews` API for each PR with pending reviewers. Calls are made in chunks of 5 to stay friendly to API rate limits.
 
@@ -141,6 +143,8 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           configuration-path: .github/mention-to-slack.yml
           bot-name: "Review Reminder"
+          # Optional: skip PRs whose title contains any of these keywords
+          ignored-terms: "WIP, DO NOT MERGE, release"
 ```
 
 ### Mapping configuration

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -12,6 +12,7 @@ import {
   execPrReviewRequestedMention,
   execReviewReminder,
   execReviewSubmittedMention,
+  parseIgnoredTerms,
 } from "../src/main.js";
 
 import { prApprovePayload } from "./fixture/real-payload-20211024-pr-approve.js";
@@ -46,6 +47,26 @@ describe("src/main", () => {
       const a = [1, 2, 3, 4];
       const b = [1, 2, 3];
       expect(arrayDiff(a, b)).toEqual([4]);
+    });
+  });
+
+  describe("parseIgnoredTerms", () => {
+    it("splits on commas and trims surrounding whitespace", () => {
+      expect(parseIgnoredTerms("wip, release ,  hold")).toEqual([
+        "wip",
+        "release",
+        "hold",
+      ]);
+    });
+
+    it("drops empty entries from extra commas", () => {
+      expect(parseIgnoredTerms("wip,,, ,release")).toEqual(["wip", "release"]);
+    });
+
+    it("returns an empty array for undefined or empty input", () => {
+      expect(parseIgnoredTerms(undefined)).toEqual([]);
+      expect(parseIgnoredTerms("")).toEqual([]);
+      expect(parseIgnoredTerms("   ")).toEqual([]);
     });
   });
 

--- a/__tests__/modules/reviewReminder.test.ts
+++ b/__tests__/modules/reviewReminder.test.ts
@@ -492,6 +492,65 @@ describe("reviewReminder", () => {
       assert(pr2);
       expect(pr2.approvalState).toBe("changes_requested");
     });
+
+    it("excludes PRs whose title contains an ignored term (partial, case-insensitive, OR)", async () => {
+      const { client, listReviews } = buildOctokit([
+        makePr({
+          number: 1,
+          title: "[WIP] add feature",
+          requested_reviewers: [{ login: "alice" }],
+        }),
+        makePr({
+          number: 2,
+          title: "Release v1.2.3",
+          requested_reviewers: [{ login: "bob" }],
+        }),
+        makePr({
+          number: 3,
+          title: "Normal change",
+          requested_reviewers: [{ login: "carol" }],
+        }),
+      ]);
+
+      // "wip" は大文字小文字を無視した部分一致、複数 term は OR で評価される
+      const result = await fetchOpenReviewRequests(client, "owner", "repo", [
+        "wip",
+        "release",
+      ]);
+
+      const names = result.map((r) => r.githubName);
+      expect(names).toEqual(["carol"]);
+      // 除外された PR では listReviews を呼ばない (carol の PR のみ)
+      expect(listReviews).toHaveBeenCalledTimes(1);
+    });
+
+    it("matches ignored terms exactly as well (full title)", async () => {
+      const { client } = buildOctokit([
+        makePr({
+          number: 1,
+          title: "skip",
+          requested_reviewers: [{ login: "alice" }],
+        }),
+      ]);
+
+      const result = await fetchOpenReviewRequests(client, "owner", "repo", [
+        "skip",
+      ]);
+      expect(result).toEqual([]);
+    });
+
+    it("keeps all PRs when ignored terms are not provided", async () => {
+      const { client } = buildOctokit([
+        makePr({
+          number: 1,
+          title: "[WIP] add feature",
+          requested_reviewers: [{ login: "alice" }],
+        }),
+      ]);
+
+      const result = await fetchOpenReviewRequests(client, "owner", "repo");
+      expect(result.map((r) => r.githubName)).toEqual(["alice"]);
+    });
   });
 
   describe("buildReviewReminderMessage section splitting", () => {

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ inputs:
     description: "If 'true', also notify the PR author when their PR receives a comment from a bot sender. Default 'false' (bot comments are skipped)."
     required: false
     default: "false"
+  ignored-terms:
+    description: "Comma-separated keywords. In 'scheduled-reminder' mode, pull requests whose title contains any of these terms (case-insensitive substring match) are excluded from the reminder."
+    required: false
 runs:
   using: "node24"
   main: "dist/index.js"

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,10 +50,18 @@ export type AllInputs = {
   runId?: string;
   type?: ActionType;
   notifyBotComment?: boolean;
+  ignoredTerms?: string[];
 };
 
 export const arrayDiff = <T>(arr1: T[], arr2: T[]) =>
   arr1.filter((i) => arr2.indexOf(i) === -1);
+
+// カンマ区切りの ignored-terms 入力を trim / 空要素除去してパースする
+export const parseIgnoredTerms = (raw: string | undefined): string[] =>
+  (raw ?? "")
+    .split(",")
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
 
 export const convertToSlackUsername = (
   githubUsernames: string[],
@@ -343,7 +351,12 @@ export const execReviewReminder = async (
   owner: string,
   repo: string,
 ): Promise<void> => {
-  const raw = await fetchOpenReviewRequests(octokit, owner, repo);
+  const raw = await fetchOpenReviewRequests(
+    octokit,
+    owner,
+    repo,
+    allInputs.ignoredTerms,
+  );
 
   const entries: ReminderEntry[] = raw.map((r) => ({
     ...r,
@@ -419,6 +432,9 @@ const getAllInputs = (): AllInputs => {
       : undefined;
   const notifyBotComment =
     getInput("notify-bot-comment", { required: false }) === "true";
+  const ignoredTerms = parseIgnoredTerms(
+    getInput("ignored-terms", { required: false }),
+  );
 
   return {
     repoToken,
@@ -429,6 +445,7 @@ const getAllInputs = (): AllInputs => {
     runId,
     type,
     notifyBotComment,
+    ignoredTerms,
   };
 };
 

--- a/src/modules/reviewReminder.ts
+++ b/src/modules/reviewReminder.ts
@@ -159,6 +159,7 @@ export const fetchOpenReviewRequests = async (
   octokit: ReturnType<typeof getOctokit>,
   owner: string,
   repo: string,
+  ignoredTerms: string[] = [],
 ): Promise<RawReminderEntry[]> => {
   const prs = await octokit.paginate(octokit.rest.pulls.list, {
     owner,
@@ -167,8 +168,16 @@ export const fetchOpenReviewRequests = async (
     per_page: 100,
   });
 
+  // GitHub 純正 Scheduled Reminders の "Ignored terms" 相当。
+  // PR タイトルにいずれかの term を部分一致 (case-insensitive) で含むものを除外する。
+  const loweredTerms = ignoredTerms.map((t) => t.toLowerCase());
+
   const pendingPrs = prs.filter((pr) => {
     if (pr.draft) return false;
+    if (loweredTerms.length > 0) {
+      const loweredTitle = pr.title.toLowerCase();
+      if (loweredTerms.some((t) => loweredTitle.includes(t))) return false;
+    }
     const reviewerCount = (pr.requested_reviewers ?? []).length;
     const teamCount = (pr.requested_teams ?? []).length;
     return reviewerCount > 0 || teamCount > 0;


### PR DESCRIPTION
## 概要

`scheduled-reminder` モードに `ignored-terms` 入力を追加し、PR タイトルに指定キーワードを含む PR をリマインド対象から除外できるようにします。GitHub 純正 Scheduled Reminders の "Ignored terms" と挙動を揃えています。

Closes #361

## 変更内容

- `action.yml`: `ignored-terms` 入力 (カンマ区切り) を追加
- `src/main.ts`: `parseIgnoredTerms` ヘルパー (カンマ区切り / trim / 空要素除去) を追加し、`AllInputs` 経由で `fetchOpenReviewRequests` に渡す
- `src/modules/reviewReminder.ts`: 既存の `pendingPrs` フィルタにタイトルキーワード判定 (**部分一致・case-insensitive**) を追加。除外された PR は `listReviews` API も呼ばれず効率的
- テスト: 部分一致 / 完全一致 / 大文字小文字違い / 複数 term の OR / 未指定で全通過 / パーサ単体
- `README.md`: 入力テーブルと scheduled-reminder セクションに説明・使用例を追記

## 動作仕様

- 未指定時は全 PR が通過 (後方互換)
- PR タイトルにいずれかの term を case-insensitive の部分一致で含む場合に除外

## 確認

- `npm test` … 全 green (140 passed | 1 todo)
- `npm run lint` (tsc --noEmit && biome check) … 通過
- `npm run build` (ncc) … 通過

> `dist/` は `.gitignore` 対象で、`release-latest-tag` ワークフローが master push 時に自動ビルド・コミットするため本 PR には含めていません。